### PR TITLE
Ignore unparsed errors when validating

### DIFF
--- a/lib/local_authority/use_case/validate_return.rb
+++ b/lib/local_authority/use_case/validate_return.rb
@@ -8,9 +8,10 @@ class LocalAuthority::UseCase::ValidateReturn
 
   def execute(type:, return_data:)
     schema = @return_template_gateway.find_by(type: type)
-    valid = JSON::Validator.validate(schema.schema.to_json, return_data)
-    invalid_paths = valid ? [] : get_paths_from_error_messages(schema, return_data)
-    { valid: valid,
+    invalid_paths = get_paths_from_error_messages(schema, return_data) || []
+
+    #:valid provides false positives if error messages are given that aren't parsed
+    { valid: invalid_paths == [],
       invalid_paths: invalid_paths }
   end
 

--- a/spec/unit/local_authority/use_case/validate_return_spec.rb
+++ b/spec/unit/local_authority/use_case/validate_return_spec.rb
@@ -64,6 +64,42 @@ describe LocalAuthority::UseCase::ValidateReturn do
   end
 
   context 'required field validation' do
+    context 'nils should be acceptable values' do
+      context 'example 1' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              required: [:complete],
+              properties: {
+                complete: {
+                  type: 'boolean',
+                  title: 'Complete'
+                }
+              }
+            }
+          end
+        end
+
+        let(:valid_return_data) do
+          {
+            complete: nil
+          }
+        end
+
+        let(:invalid_return_data) do
+          {
+
+          }
+        end
+
+        let(:invalid_return_data_paths) do
+          [[:complete]]
+        end
+      end
+    end
     context 'single field' do
       context 'example 1' do
         it_should_behave_like 'required field validation'


### PR DESCRIPTION
Why - Because not all errors are relevent to us we only parse a specific subset however this was not reflected in the ':valid' member of the hash returned from the validation usecase.