### PR TITLE
Update schema dependencies to be valid

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -181,6 +181,13 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   }
                                 },
                               }
+                            },
+                            {
+                              properties: {
+                                baselineOutlinePlanningPermissionGranted: {
+                                  enum: ['Yes']
+                                }
+                              }
                             }
                           ]
                         }
@@ -424,6 +431,13 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                   }
                                 }
                               }
+                            },
+                            {
+                              properties: {
+                                s106Requirement: {
+                                  enum: ['No']
+                                }
+                              }
                             }
                           ]
                         }
@@ -558,10 +572,24 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                           }
                                         }
                                       }
+                                    },
+                                    {
+                                      properties: {
+                                        landAcquisitionRequired: {
+                                          enum: ['No']
+                                        }
+                                      }
                                     }
                                   ]
                                 }
                               }
+                            }
+                          }
+                        },
+                        {
+                          properties: {
+                            laHasControlOfSite: {
+                              enum: ['Yes']
                             }
                           }
                         }

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -49,7 +49,7 @@ describe 'Performing Return on HIF Project' do
           description: 'A house of cats',
 
           outlinePlanningStatus: {
-            granted: 'Yes',
+            granted: 'No',
             grantedReference: 'The Dogs',
             targetSubmission: '2020-01-01',
             targetGranted: '2020-01-01',

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -7,7 +7,7 @@
       },
       "planning": {
         "outlinePlanning": {
-          "baselineOutlinePlanningPermissionGranted": "Yes",
+          "baselineOutlinePlanningPermissionGranted": "No",
           "baselineSummaryOfCriticalPath": "Summary of critical path",
           "planningSubmitted": {
             "baselineSubmitted": "2020-01-01"

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -7,7 +7,7 @@
       },
       "planning": {
         "outlinePlanning": {
-          "baselineOutlinePlanningPermissionGranted": "Yes",
+          "baselineOutlinePlanningPermissionGranted": "No",
           "baselineSummaryOfCriticalPath": "Summary of critical path",
           "planningSubmitted": {
             "baselineSubmitted": "2020-01-01"


### PR DESCRIPTION
WHAT - Adds alternative values to dependencies in enums

WHY - Without these the schema is marked as invalid