### PR TITLE
Add risk: true property to json schema

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -1005,7 +1005,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       title: 'Baseline Risks',
                       items: {
                         type: 'object',
-                        horizontal: true,
+                        risk: true,
                         properties: {
                           riskBaselineRisk: {
                             sourceKey: %i[baseline_data infrastructures risksToAchievingTimescales descriptionOfRisk],


### PR DESCRIPTION
WHAT/WHY
A marker in the backend to signal when the UI schema should be using the RiskField component.
