### PR TITLE
Check email string

### DIFF
--- a/lib/homes_england/use_case/add_user.rb
+++ b/lib/homes_england/use_case/add_user.rb
@@ -6,7 +6,7 @@ class HomesEngland::UseCase::AddUser
   def execute(email:)
     @user_gateway.create(
       LocalAuthority::Domain::User.new.tap do |u|
-        u.email = email
+        u.email = email.downcase
       end
     )
   end

--- a/lib/local_authority/use_case/check_email.rb
+++ b/lib/local_authority/use_case/check_email.rb
@@ -6,7 +6,7 @@ class LocalAuthority::UseCase::CheckEmail
   end
 
   def execute(email_address:, project_id:)
-    user = @users_gateway.find_by(email: email_address)
+    user = @users_gateway.find_by(email: email_address.downcase)
     if user.nil?
       { valid: false }
     else

--- a/spec/unit/homes_england/use_case/add_user_spec.rb
+++ b/spec/unit/homes_england/use_case/add_user_spec.rb
@@ -5,14 +5,30 @@ describe HomesEngland::UseCase::AddUser do
     it 'example 1' do
       use_case.execute(email: 'cat@cathouse.com')
       expect(user_gateway).to have_received(:create) do |u|
-        u.email = 'cat@cathouse.com'
+        expect(u.email).to eq('cat@cathouse.com')
       end
     end
 
     it 'example 2' do
-      use_case.execute(email: 'cat@cathouse.com')
+      use_case.execute(email: 'dog@doghouse.com')
       expect(user_gateway).to have_received(:create) do |u|
-        u.email = 'dog@doghouse.com'
+        expect(u.email).to eq('dog@doghouse.com')
+      end
+    end
+  end
+
+  context 'removes upper case from email address' do
+    it 'example 1' do
+      use_case.execute(email: 'THaTCaTHouSe@CaThouse.com')
+      expect(user_gateway).to have_received(:create) do |u|
+        expect(u.email).to eq('thatcathouse@cathouse.com')
+      end
+    end
+
+    it 'example 2' do
+      use_case.execute(email: 'ThaTDoGHOUSE@DOGHOUSe.com')
+      expect(user_gateway).to have_received(:create) do |u|
+        expect(u.email).to eq('thatdoghouse@doghouse.com')
       end
     end
   end

--- a/spec/unit/local_authority/use_case/check_email_spec.rb
+++ b/spec/unit/local_authority/use_case/check_email_spec.rb
@@ -19,6 +19,19 @@ describe LocalAuthority::UseCase::CheckEmail do
     end
   end
 
+  context 'converts email address to lower case' do
+    let(:users_gateway_spy) { spy }
+    it 'example 1' do
+      use_case.execute(email_address: 'ExamPLE@EXAMPLE.com', project_id: 1415926535)
+      expect(users_gateway_spy).to have_received(:find_by).with(email: 'example@example.com')
+    end
+
+    it 'example 2' do
+      use_case.execute(email_address: 'HELLO@WoRLD.cOM', project_id: 4096)
+      expect(users_gateway_spy).to have_received(:find_by).with(email: 'hello@world.com')
+    end
+  end
+
   context 'returns a boolean' do
     context 'existent email' do
       context 'with an accessible project' do


### PR DESCRIPTION
WHAT
converts email strings to lowercase 

WHY 
currently email addresses are not being because because the case is mixed