### PR TITLE
Add logging to STDOUT

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ jobs:
 
     environment:
       DATABASE_URL: 'postgres://circleci:super-secret@localhost/monitor_api'
+      NO_LOGS: 'true'
 
     steps:
       - checkout

--- a/bin/run_tests.sh
+++ b/bin/run_tests.sh
@@ -13,4 +13,6 @@ while ! psql $DATABASE_URL -c 'SELECT 1'; do
     echo 'Waiting for db'; sleep 3;
 done
 
+export NO_LOGS=true
+
 bundle exec guard

--- a/lib/common/namespaces.rb
+++ b/lib/common/namespaces.rb
@@ -1,1 +1,3 @@
-module Common; end
+module Common
+  module Proxy; end
+end

--- a/lib/common/proxy/logging.rb
+++ b/lib/common/proxy/logging.rb
@@ -1,0 +1,29 @@
+class Common::Proxy::Logging
+  def initialize(logger:, use_case:)
+    @logger = logger
+    @use_case = use_case
+  end
+
+  def execute(request)
+    @logger&.info(
+      {
+        message_type: 'before-use-case-called',
+        name: @use_case.class.name,
+        request: request
+      }.inspect
+    )
+
+    response = @use_case.execute(request)
+
+    @logger&.info(
+      {
+        message_type: 'after-use-case-called',
+        name: @use_case.class.name,
+        request: request,
+        response: response
+      }.inspect
+    )
+
+    response
+  end
+end

--- a/lib/dependencies.rb
+++ b/lib/dependencies.rb
@@ -1,6 +1,6 @@
 class Dependencies
-  def self.use_case_factory
-    factory = UseCaseFactory.new
+  def self.dependency_factory
+    factory = DependencyFactory.new
     database = DatabaseAdministrator::Postgres.new.existing_database
 
     factory.database = database

--- a/lib/dependency_factory.rb
+++ b/lib/dependency_factory.rb
@@ -4,19 +4,30 @@ class DependencyFactory
   attr_accessor :database
 
   def initialize
-    @container = Dry::Container.new
+    @use_case_container = Dry::Container.new
+    @gateway_container = Dry::Container.new
   end
 
   def default_dependencies
     LocalAuthority::UseCases.register(self)
+    LocalAuthority::Gateways.register(self)
     HomesEngland::UseCases.register(self)
+    HomesEngland::Gateways.register(self)
   end
 
   def define_use_case(use_case, &block)
-    @container.register(use_case) { block.call }
+    @use_case_container.register(use_case) { block.call }
+  end
+
+  def define_gateway(gateway, &block)
+    @gateway_container.register(gateway) { block.call }
   end
 
   def get_use_case(use_case)
-    @container.resolve(use_case)
+    @use_case_container.resolve(use_case)
+  end
+
+  def get_gateway(gateway)
+    @gateway_container.resolve(gateway)
   end
 end

--- a/lib/dependency_factory.rb
+++ b/lib/dependency_factory.rb
@@ -6,6 +6,8 @@ class DependencyFactory
   def initialize
     @use_case_container = Dry::Container.new
     @gateway_container = Dry::Container.new
+
+    setup_logger
   end
 
   def default_dependencies
@@ -24,10 +26,19 @@ class DependencyFactory
   end
 
   def get_use_case(use_case)
-    @use_case_container.resolve(use_case)
+    Common::Proxy::Logging.new(
+      logger: @logger,
+      use_case: @use_case_container.resolve(use_case)
+    )
   end
 
   def get_gateway(gateway)
     @gateway_container.resolve(gateway)
+  end
+
+  def setup_logger
+    return unless ENV['NO_LOGS'].nil?
+
+    @logger = Logger.new(STDOUT)
   end
 end

--- a/lib/dependency_factory.rb
+++ b/lib/dependency_factory.rb
@@ -1,6 +1,6 @@
 require 'dry/container'
 
-class UseCaseFactory
+class DependencyFactory
   attr_accessor :database
 
   def initialize

--- a/lib/homes_england/gateways.rb
+++ b/lib/homes_england/gateways.rb
@@ -1,0 +1,18 @@
+class HomesEngland::Gateways
+  def self.register(builder)
+    builder.define_gateway :project do
+      HomesEngland::Gateway::SequelProject.new(database: builder.database)
+    end
+
+    builder.define_gateway :template do
+      HomesEngland::Gateway::InMemoryTemplate.new(
+        template_builder: builder.get_use_case(:template_builder)
+      )
+    end
+
+    builder.define_gateway :template_builder do
+      HomesEngland::Builder::Template::TemplateBuilder.new
+    end
+  end
+end
+

--- a/lib/homes_england/use_cases.rb
+++ b/lib/homes_england/use_cases.rb
@@ -2,10 +2,6 @@
 
 class HomesEngland::UseCases
   def self.register(builder)
-    builder.define_use_case :project_gateway do
-      HomesEngland::Gateway::SequelProject.new(database: builder.database)
-    end
-
     builder.define_use_case :template_gateway do
       HomesEngland::Gateway::InMemoryTemplate.new(template_builder:
                                                     builder.get_use_case(:template_builder) )
@@ -17,49 +13,49 @@ class HomesEngland::UseCases
 
     builder.define_use_case :create_new_project do
       HomesEngland::UseCase::CreateNewProject.new(
-        project_gateway: builder.get_use_case(:project_gateway)
+        project_gateway: builder.get_gateway(:project)
       )
     end
 
     builder.define_use_case :find_project do
       HomesEngland::UseCase::FindProject.new(
-        project_gateway: builder.get_use_case(:project_gateway)
+        project_gateway: builder.get_gateway(:project)
       )
     end
 
     builder.define_use_case :update_project do
       HomesEngland::UseCase::UpdateProject.new(
-        project_gateway: builder.get_use_case(:project_gateway)
+        project_gateway: builder.get_gateway(:project)
       )
     end
 
     builder.define_use_case :get_schema_for_project do
       HomesEngland::UseCase::GetSchemaForProject.new(
-        template_gateway: builder.get_use_case(:template_gateway)
+        template_gateway: builder.get_gateway(:template)
       )
     end
 
     builder.define_use_case :populate_template do
       HomesEngland::UseCase::PopulateTemplate.new(
-        template_gateway: builder.get_use_case(:template_gateway)
+        template_gateway: builder.get_gateway(:template)
       )
     end
 
     builder.define_use_case :add_user do
       HomesEngland::UseCase::AddUser.new(
-        user_gateway: builder.get_use_case(:users_gateway)
+        user_gateway: builder.get_gateway(:users)
       )
     end
 
     builder.define_use_case :add_user_to_project do
       HomesEngland::UseCase::AddUserToProject.new(
-        user_gateway: builder.get_use_case(:users_gateway)
+        user_gateway: builder.get_gateway(:users)
       )
     end
 
     builder.define_use_case :get_project_users do
       HomesEngland::UseCase::GetProjectUsers.new(
-        user_gateway: builder.get_use_case(:users_gateway)
+        user_gateway: builder.get_gateway(:users)
       )
     end
   end

--- a/lib/local_authority/gateways.rb
+++ b/lib/local_authority/gateways.rb
@@ -1,0 +1,35 @@
+class LocalAuthority::Gateways
+  def self.register(builder)
+    builder.define_gateway :return_gateway do
+      LocalAuthority::Gateway::SequelReturn.new(database: builder.database)
+    end
+
+    builder.define_gateway :return_update_gateway do
+      LocalAuthority::Gateway::SequelReturnUpdate.new(
+        database: builder.database
+      )
+    end
+
+    builder.define_gateway :return_template do
+      LocalAuthority::Gateway::InMemoryReturnTemplate.new
+    end
+
+    builder.define_gateway :users do
+      LocalAuthority::Gateway::SequelUsers.new(
+        database: builder.database
+      )
+    end
+
+    builder.define_gateway :access_token do
+      LocalAuthority::Gateway::InMemoryAccessTokenGateway.new
+    end
+
+    builder.define_gateway :notification do
+      LocalAuthority::Gateway::GovEmailNotificationGateway.new
+    end
+
+    builder.define_gateway :api_key do
+      LocalAuthority::Gateway::InMemoryAPIKeyGateway.new
+    end
+  end
+end

--- a/lib/local_authority/use_case/find_path_data.rb
+++ b/lib/local_authority/use_case/find_path_data.rb
@@ -1,5 +1,5 @@
 class LocalAuthority::UseCase::FindPathData
-  def execute(baseline_data, path)
+  def execute(baseline_data:, path:)
     found = search_hash(baseline_data, path)
     if !(found.nil? || found.empty?)
       { found: found }

--- a/lib/local_authority/use_case/get_return_template_path_types.rb
+++ b/lib/local_authority/use_case/get_return_template_path_types.rb
@@ -1,6 +1,6 @@
 class LocalAuthority::UseCase::GetReturnTemplatePathTypes
   using LocalAuthority::Refinement::HashHasPath
-  
+
   def initialize(template_gateway:)
     @template_gateway = template_gateway
   end

--- a/lib/local_authority/use_case/populate_return_template.rb
+++ b/lib/local_authority/use_case/populate_return_template.rb
@@ -30,8 +30,8 @@ class LocalAuthority::UseCase::PopulateReturnTemplate
     path_types = @get_return_template_path_types.execute(type: type, path: copy_path_pair[:to])[:path_types].drop(1)
 
     found_data = @find_path_data.execute(
-      source_data,
-      copy_path_pair[:from]
+      baseline_data: source_data,
+      path: copy_path_pair[:from]
     )[:found]
 
     descend_hash_and_bury(

--- a/lib/local_authority/use_cases.rb
+++ b/lib/local_authority/use_cases.rb
@@ -2,45 +2,13 @@
 
 class LocalAuthority::UseCases
   def self.register(builder)
-    builder.define_use_case :return_gateway do
-      LocalAuthority::Gateway::SequelReturn.new(database: builder.database)
-    end
-
-    builder.define_use_case :return_update_gateway do
-      LocalAuthority::Gateway::SequelReturnUpdate.new(
-        database: builder.database
-      )
-    end
-
-    builder.define_use_case :return_template_gateway do
-      LocalAuthority::Gateway::InMemoryReturnTemplate.new
-    end
-
-    builder.define_use_case :users_gateway do
-      LocalAuthority::Gateway::SequelUsers.new(
-        database: builder.database
-      )
-    end
-
-    builder.define_use_case :access_token_gateway do
-      LocalAuthority::Gateway::InMemoryAccessTokenGateway.new
-    end
-
-    builder.define_use_case :notification_gateway do
-      LocalAuthority::Gateway::GovEmailNotificationGateway.new
-    end
-
-    builder.define_use_case :api_key_gateway do
-      LocalAuthority::Gateway::InMemoryAPIKeyGateway.new
-    end
-
     builder.define_use_case :find_path_data do
       LocalAuthority::UseCase::FindPathData.new
     end
 
     builder.define_use_case :get_schema_copy_paths do
       LocalAuthority::UseCase::GetSchemaCopyPaths.new(
-        template_gateway: builder.get_use_case(:return_template_gateway)
+        template_gateway: builder.get_gateway(:return_template)
       )
     end
 
@@ -54,8 +22,8 @@ class LocalAuthority::UseCases
 
     builder.define_use_case :get_base_return do
       LocalAuthority::UseCase::GetBaseReturn.new(
-        return_gateway: builder.get_use_case(:return_template_gateway),
-        project_gateway: builder.get_use_case(:project_gateway),
+        return_gateway: builder.get_gateway(:return_template),
+        project_gateway: builder.get_gateway(:project),
         populate_return_template: builder.get_use_case(:populate_return_template),
         get_returns: builder.get_use_case(:get_returns)
       )
@@ -63,27 +31,27 @@ class LocalAuthority::UseCases
 
     builder.define_use_case :create_return do
       LocalAuthority::UseCase::CreateReturn.new(
-        return_gateway: builder.get_use_case(:return_gateway),
-        return_update_gateway: builder.get_use_case(:return_update_gateway)
+        return_gateway: builder.get_gateway(:return_gateway),
+        return_update_gateway: builder.get_gateway(:return_update_gateway)
       )
     end
 
     builder.define_use_case :update_return do
       LocalAuthority::UseCase::UpdateReturn.new(
-        return_gateway: builder.get_use_case(:return_gateway)
+        return_gateway: builder.get_gateway(:return_gateway)
       )
     end
 
     builder.define_use_case :soft_update_return do
       LocalAuthority::UseCase::SoftUpdateReturn.new(
-        return_update_gateway: builder.get_use_case(:return_update_gateway)
+        return_update_gateway: builder.get_gateway(:return_update_gateway)
       )
     end
 
     builder.define_use_case :get_return do
       LocalAuthority::UseCase::GetReturn.new(
-        return_gateway: builder.get_use_case(:return_gateway),
-        return_update_gateway: builder.get_use_case(:return_update_gateway),
+        return_gateway: builder.get_gateway(:return_gateway),
+        return_update_gateway: builder.get_gateway(:return_update_gateway),
         calculate_return: builder.get_use_case(:calculate_hif_return),
         get_returns: builder.get_use_case(:get_returns)
       )
@@ -91,43 +59,43 @@ class LocalAuthority::UseCases
 
     builder.define_use_case :submit_return do
       LocalAuthority::UseCase::SubmitReturn.new(
-        return_gateway: builder.get_use_case(:return_gateway)
+        return_gateway: builder.get_gateway(:return_gateway)
       )
     end
 
     builder.define_use_case :get_schema_for_return do
       LocalAuthority::UseCase::GetSchemaForReturn.new(
-        project_gateway: builder.get_use_case(:project_gateway),
-        return_gateway: builder.get_use_case(:return_gateway),
-        template_gateway: builder.get_use_case(:return_template_gateway)
+        project_gateway: builder.get_gateway(:project),
+        return_gateway: builder.get_gateway(:return_gateway),
+        template_gateway: builder.get_gateway(:return_template)
       )
     end
 
     builder.define_use_case :get_returns do
       LocalAuthority::UseCase::GetReturns.new(
-        return_gateway: builder.get_use_case(:return_gateway),
-        return_update_gateway: builder.get_use_case(:return_update_gateway)
+        return_gateway: builder.get_gateway(:return_gateway),
+        return_update_gateway: builder.get_gateway(:return_update_gateway)
       )
     end
 
     builder.define_use_case :check_email do
       LocalAuthority::UseCase::CheckEmail.new(
-        users_gateway: builder.get_use_case(:users_gateway)
+        users_gateway: builder.get_gateway(:users)
       )
     end
 
     builder.define_use_case :create_access_token do
       LocalAuthority::UseCase::CreateAccessToken.new(
-        access_token_gateway: builder.get_use_case(
-          :access_token_gateway
+        access_token_gateway: builder.get_gateway(
+          :access_token
         )
       )
     end
 
     builder.define_use_case :expend_access_token do
       LocalAuthority::UseCase::ExpendAccessToken.new(
-        access_token_gateway: builder.get_use_case(
-          :access_token_gateway
+        access_token_gateway: builder.get_gateway(
+          :access_token
         ), create_api_key: builder.get_use_case(:create_api_key)
       )
     end
@@ -138,7 +106,7 @@ class LocalAuthority::UseCases
 
     builder.define_use_case :send_notification do
       LocalAuthority::UseCase::SendNotification.new(
-        notification_gateway: builder.get_use_case(:notification_gateway)
+        notification_gateway: builder.get_gateway(:notification)
       )
     end
 
@@ -152,26 +120,26 @@ class LocalAuthority::UseCases
 
     builder.define_use_case :validate_return do
       LocalAuthority::UseCase::ValidateReturn.new(
-        return_template_gateway: builder.get_use_case(:return_template_gateway),
+        return_template_gateway: builder.get_gateway(:return_template),
         get_return_template_path_titles: builder.get_use_case(:get_return_template_path_titles)
       )
     end
 
     builder.define_use_case :get_return_template_path_titles do
       LocalAuthority::UseCase::GetReturnTemplatePathTitles.new(
-        template_gateway: builder.get_use_case(:return_template_gateway)
+        template_gateway: builder.get_gateway(:return_template)
       )
     end
 
     builder.define_use_case :get_return_template_path_types do
       LocalAuthority::UseCase::GetReturnTemplatePathTypes.new(
-        template_gateway: builder.get_use_case(:return_template_gateway)
+        template_gateway: builder.get_gateway(:return_template)
       )
     end
 
     builder.define_use_case :send_return_submission_notification do
       LocalAuthority::UseCase::SendReturnSubmissionNotification.new(
-        email_notification_gateway: builder.get_use_case(:notification_gateway)
+        email_notification_gateway: builder.get_gateway(:notification)
       )
     end
 

--- a/spec/acceptance/homes_england/create_new_hif_project_spec.rb
+++ b/spec/acceptance/homes_england/create_new_hif_project_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Creating a new HIF FileProject' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   it 'should save project and return a unique id' do
     project_baseline = {

--- a/spec/acceptance/homes_england/update_project_spec.rb
+++ b/spec/acceptance/homes_england/update_project_spec.rb
@@ -1,8 +1,8 @@
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Updating a HIF Project' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   it 'should update a project' do
     project_baseline = {

--- a/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
+++ b/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
@@ -8,7 +8,7 @@ describe 'Authorises the user' do
 
   before { ENV['HMAC_SECRET'] = 'Meow' }
 
-  after { get_use_case(:access_token_gateway).clear }
+  after { get_gateway(:access_token).clear }
 
   context 'Correct access token for project' do
     it 'should create a valid access token for project 1' do

--- a/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
+++ b/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Authorises the user' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   before { ENV['HMAC_SECRET'] = 'Meow' }
 

--- a/spec/acceptance/local_authority/calculate_hif_return_spec.rb
+++ b/spec/acceptance/local_authority/calculate_hif_return_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Calculated return' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   it 'creates a return with calculated fields' do
     initial_return_input_data = {

--- a/spec/acceptance/local_authority/get_returns_spec.rb
+++ b/spec/acceptance/local_authority/get_returns_spec.rb
@@ -1,8 +1,8 @@
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Getting multiple returns' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   let(:returns_for_project_1) do
     [

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -63,7 +63,7 @@ describe 'Performing Return on HIF Project' do
 
   it 'should keep track of Returns' do
     base_return = get_use_case(:get_base_return).execute(project_id: project_id)
-    
+
     expect(base_return[:base_return][:data]).to eq(expected_base_return)
 
     initial_return = {

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Performing Return on HIF Project' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   def update_return(id:, data:)
     get_use_case(:update_return).execute(return_id: id, data: data[:data])

--- a/spec/acceptance/local_authority/validate_return_spec.rb
+++ b/spec/acceptance/local_authority/validate_return_spec.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 require 'rspec'
-require_relative '../shared_context/use_case_factory'
+require_relative '../shared_context/dependency_factory'
 
 describe 'Validates HIF return' do
-  include_context 'use case factory'
+  include_context 'dependency factory'
 
   context 'Invalid HIF return' do
     # percent complete set to > 100

--- a/spec/acceptance/shared_context/dependency_factory.rb
+++ b/spec/acceptance/shared_context/dependency_factory.rb
@@ -1,12 +1,12 @@
-RSpec.shared_context 'use case factory' do
+RSpec.shared_context 'dependency factory' do
   include_context 'with database'
 
   def get_use_case(use_case)
-    use_case_factory.get_use_case(use_case)
+    dependency_factory.get_use_case(use_case)
   end
 
-  let(:use_case_factory) do
-    factory = ::UseCaseFactory.new
+  let(:dependency_factory) do
+    factory = ::DependencyFactory.new
     factory.database = database
 
     factory.default_dependencies

--- a/spec/acceptance/shared_context/dependency_factory.rb
+++ b/spec/acceptance/shared_context/dependency_factory.rb
@@ -5,6 +5,10 @@ RSpec.shared_context 'dependency factory' do
     dependency_factory.get_use_case(use_case)
   end
 
+  def get_gateway(gateway)
+    dependency_factory.get_gateway(gateway)
+  end
+
   let(:dependency_factory) do
     factory = ::DependencyFactory.new
     factory.database = database

--- a/spec/unit/common/logging_spec.rb
+++ b/spec/unit/common/logging_spec.rb
@@ -1,0 +1,131 @@
+describe Common::Proxy::Logging do
+  describe 'Given a logger with the info method' do
+    let(:logger_spy) { spy(:info) }
+    let(:response) { proxy.execute(request) }
+    let(:proxy) { described_class.new(logger: logger_spy, use_case: use_case_spy) }
+    before { response }
+
+    describe 'Example one' do
+      class ExampleUseCaseOne
+        attr_reader :executed_with
+
+        def initialize(response)
+          @response = response
+        end
+
+        def execute(request)
+          @executed_with = request
+          @response
+        end
+      end
+
+      let(:use_case_spy) { ExampleUseCaseOne.new({ cats: 'Are the best'}) }
+      let(:request) { { cat: 'meow', dog: 'woof' } }
+
+      it 'Calls the usecase execute method' do
+        expect(use_case_spy.executed_with).not_to be_nil
+      end
+
+      it 'Calls the usecase execute method with the given arguments' do
+        expect(use_case_spy.executed_with).to eq(cat: 'meow', dog: 'woof')
+      end
+
+      it 'Returns the response from the usecase' do
+        expect(response).to eq({cats: 'Are the best'})
+      end
+
+      it 'Logs the correct message' do
+        expect(logger_spy).to have_received(:info).with(
+          {
+            message_type: 'before-use-case-called',
+            name: 'ExampleUseCaseOne',
+            request: { cat: 'meow', dog: 'woof'}
+          }.inspect
+        )
+      end
+
+      it 'Logs the correct message' do
+        expect(logger_spy).to have_received(:info).with(
+          {
+            message_type: 'after-use-case-called',
+            name: 'ExampleUseCaseOne',
+            request: { cat: 'meow', dog: 'woof'},
+            response: { cats: 'Are the best' }
+          }.inspect
+        )
+      end
+    end
+
+    describe 'Example two' do
+      class ExampleUseCaseTwo
+        attr_reader :executed_with
+
+        def initialize(response)
+          @response = response
+        end
+
+        def execute(request)
+          @executed_with = request
+          @response
+        end
+      end
+
+      let(:use_case_spy) { ExampleUseCaseTwo.new({ dogs: 'Are also the best'}) }
+      let(:request) { { cow: 'moo', chicken: 'cluck' } }
+
+      it 'Calls the usecase execute method' do
+        expect(use_case_spy.executed_with).not_to be_nil
+      end
+
+      it 'Calls the usecase execute method with the given arguments' do
+        expect(use_case_spy.executed_with).to eq(cow: 'moo', chicken: 'cluck')
+      end
+
+      it 'Returns the response from the usecase' do
+        expect(response).to eq({dogs: 'Are also the best'})
+      end
+
+      it 'Logs the correct before message' do
+        expect(logger_spy).to have_received(:info).with(
+          {
+            message_type: 'before-use-case-called',
+            name: 'ExampleUseCaseTwo',
+            request: { cow: 'moo', chicken: 'cluck' }
+          }.inspect
+        )
+      end
+
+      it 'Logs the correct after message' do
+        expect(logger_spy).to have_received(:info).with(
+          {
+            message_type: 'after-use-case-called',
+            name: 'ExampleUseCaseTwo',
+            request: { cow: 'moo', chicken: 'cluck' },
+            response: { dogs: 'Are also the best'}
+          }.inspect
+        )
+      end
+    end
+  end
+
+  describe 'Given a nil logger' do
+    let(:use_case_spy) { spy(execute: {dog: 'woof'}) }
+    let(:proxy) { described_class.new(logger: nil, use_case: use_case_spy)}
+
+    it 'Does not raise an error' do
+      expect { proxy.execute({cat: 'meow'}) }.not_to raise_error
+    end
+
+    it 'Calls the usecase' do
+      proxy.execute(cat: 'meow')
+
+      expect(use_case_spy).to have_received(:execute).with({cat: 'meow'})
+    end
+
+    it 'Returns the response from the usecase' do
+      response = proxy.execute(cat: 'meow')
+
+      expect(response).to eq(dog: 'woof')
+    end
+  end
+end

--- a/spec/unit/local_authority/use_case/find_path_data_spec.rb
+++ b/spec/unit/local_authority/use_case/find_path_data_spec.rb
@@ -1,6 +1,11 @@
 describe LocalAuthority::UseCase::FindPathData do
 
-  let(:use_case) { described_class.new.execute(baseline_data, path) }
+  let(:use_case) do 
+    described_class.new.execute(
+      baseline_data: baseline_data, 
+      path: path
+    )
+  end
 
   context 'with simple paths' do
     context 'example 1' do
@@ -21,7 +26,6 @@ describe LocalAuthority::UseCase::FindPathData do
 
       let(:path) { [:sounds, :dog] }
 
-      let(:use_case) { described_class.new.execute(baseline_data, path) }
       it 'can find a simple path' do
         expect(use_case).to eq(found: 'woof')
       end

--- a/spec/unit/local_authority/use_case/populate_return_template_spec.rb
+++ b/spec/unit/local_authority/use_case/populate_return_template_spec.rb
@@ -172,7 +172,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
 
     let(:find_path_data) do
       Class.new do
-        def execute(_baseline_data, path)
+        def execute(baseline_data:, path: )
           if path == %i[cats sound]
             { found: ['Meow'] }
           elsif path == %i[cats breed]
@@ -275,7 +275,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
 
     let(:find_path_data) do
       Class.new do
-        def execute(_baseline_data, path)
+        def execute(baseline_data:, path:)
           if path == %i[cats sound]
             { found: 'Meow' }
           elsif path == %i[dogs sound]
@@ -798,7 +798,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
 
     let(:find_path_data) do
       Class.new do
-        def execute(_baseline_data, path)
+        def execute(baseline_data:, path:)
           if path == %i[baseline_data cats name]
             { found: 'Meow' }
           elsif path == %i[baseline_data cats breed]
@@ -884,7 +884,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
 
     let(:find_path_data) do
       Class.new do
-        def execute(_baseline_data, path)
+        def execute(baseline_data:, path:)
           if path == %i[baseline_data dogs name]
             { found: 'Meow' }
           elsif path == %i[baseline_data cats breed]
@@ -961,7 +961,7 @@ describe LocalAuthority::UseCase::PopulateReturnTemplate do
     let(:baseline_data) { { cats: { name: 'tom' } } }
     let(:find_path_data) do
       Class.new do
-        def execute(_baseline_data, path)
+        def execute(baseline_data:, path:)
           if path == %i[baseline_data cats name]
             { found: ['Timmy'] }
           elsif path == %i[baseline_data cats breed]


### PR DESCRIPTION
WHY
- We can't easily see what use cases are being called and with what data

WHAT
- Adds a logging proxy around our use cases to log before/after requests and responses
- Separates out use case factory to two separate containers, one for gateways and one for use cases as gateways do not implement the same interface as use cases do
- Fixed use case which did not use named arguments