### PR TITLE
Disable log buffering

### DIFF
--- a/config.ru
+++ b/config.ru
@@ -7,4 +7,6 @@ unless ENV['SENTRY_DSN'].nil?
   use Raven::Rack
 end
 
+$stdout.sync = true
+
 run DeliveryMechanism::WebRoutes


### PR DESCRIPTION
In order to take advantage of real time logging on Heroku we need to disable the log buffering

https://devcenter.heroku.com/articles/logging