### PR TITLE
Create a status for projects

### DIFF
--- a/db/migrations/1_create_projects_table.rb
+++ b/db/migrations/1_create_projects_table.rb
@@ -3,6 +3,7 @@ Sequel.migration do
     create_table :projects do
       primary_key :id, type: :Bignum
       String :type
+      String :status
       column :data, 'json'
     end
   end

--- a/db/migrations/1_create_projects_table.rb
+++ b/db/migrations/1_create_projects_table.rb
@@ -3,7 +3,6 @@ Sequel.migration do
     create_table :projects do
       primary_key :id, type: :Bignum
       String :type
-      String :status
       column :data, 'json'
     end
   end

--- a/db/migrations/7_add_status_to_projects_table.rb
+++ b/db/migrations/7_add_status_to_projects_table.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:projects) do
+      add_column :status, String, default: 'Submitted'
+    end
+  end
+end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -225,6 +225,16 @@ module DeliveryMechanism
       end
     end
 
+    post '/project/submit' do
+      guard_access env, params, request do |request_hash|
+        @dependency_factory.get_use_case(:submit_project).execute(
+          project_id: request_hash[:project_id].to_i
+        )
+
+        response.status = 200
+      end
+    end 
+
     def get_hash(request)
       body = request.body.read
       return nil if body.to_s.empty?

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -179,6 +179,7 @@ module DeliveryMechanism
         content_type 'application/json'
         response.body = {
           type: project[:type],
+          status: project[:status],
           data: Common::DeepCamelizeKeys.to_camelized_hash(project[:data]),
           schema: schema
         }.to_json

--- a/lib/homes_england/domain/project.rb
+++ b/lib/homes_england/domain/project.rb
@@ -1,3 +1,7 @@
 class HomesEngland::Domain::Project
-  attr_accessor :type, :data
+  attr_accessor :type, :data, :status
+  
+  def initialize
+    @status = 'Draft'
+  end
 end

--- a/lib/homes_england/gateway/sequel_project.rb
+++ b/lib/homes_england/gateway/sequel_project.rb
@@ -26,7 +26,8 @@ class HomesEngland::Gateway::SequelProject
       .where(id: id)
       .update(
         type: project.type,
-        data: Sequel.pg_json(project.data)
+        data: Sequel.pg_json(project.data),
+        status: project.status
       )
 
     { success: updated > 0 }

--- a/lib/homes_england/gateway/sequel_project.rb
+++ b/lib/homes_england/gateway/sequel_project.rb
@@ -6,7 +6,8 @@ class HomesEngland::Gateway::SequelProject
   def create(project)
     @database[:projects].insert(
       type: project.type,
-      data: Sequel.pg_json(project.data)
+      data: Sequel.pg_json(project.data),
+      status: project.status
     )
   end
 
@@ -16,6 +17,7 @@ class HomesEngland::Gateway::SequelProject
     HomesEngland::Domain::Project.new.tap do |p|
       p.type = row[:type]
       p.data = Common::DeepSymbolizeKeys.to_symbolized_hash(row[:data].to_h)
+      p.status = row[:status]
     end
   end
 
@@ -29,5 +31,8 @@ class HomesEngland::Gateway::SequelProject
 
     { success: updated > 0 }
   end
-end
 
+  def submit(id:)
+    @database[:projects].where(id: id).update(status: 'Submitted')
+  end
+end

--- a/lib/homes_england/use_case/find_project.rb
+++ b/lib/homes_england/use_case/find_project.rb
@@ -7,8 +7,8 @@ class HomesEngland::UseCase::FindProject
     project = @project_gateway.find_by(id: id)
     {
       type: project.type,
-      data: project.data
+      data: project.data,
+      status: project.status
     }
   end
 end
-

--- a/lib/homes_england/use_case/submit_project.rb
+++ b/lib/homes_england/use_case/submit_project.rb
@@ -1,0 +1,9 @@
+class HomesEngland::UseCase::SubmitProject
+  def initialize(project_gateway:)
+    @project_gateway = project_gateway
+  end
+
+  def execute(project_id:)
+    @project_gateway.submit(id: project_id)
+  end
+end

--- a/lib/homes_england/use_case/update_project.rb
+++ b/lib/homes_england/use_case/update_project.rb
@@ -7,6 +7,7 @@ class HomesEngland::UseCase::UpdateProject
     updated_project = HomesEngland::Domain::Project.new
     updated_project.type = project[:type]
     updated_project.data = project[:baseline]
+    updated_project.status = 'Draft'
 
     successful = @project_gateway.update(id: id, project: updated_project)[:success]
 

--- a/lib/homes_england/use_cases.rb
+++ b/lib/homes_england/use_cases.rb
@@ -20,6 +20,12 @@ class HomesEngland::UseCases
       )
     end
 
+    builder.define_use_case :submit_project do
+      HomesEngland::UseCase::SubmitProject.new(
+        project_gateway: builder.get_gateway(:project)
+      )
+    end
+
     builder.define_use_case :get_schema_for_project do
       HomesEngland::UseCase::GetSchemaForProject.new(
         template_gateway: builder.get_gateway(:template)

--- a/spec/acceptance/homes_england/create_new_hif_project_spec.rb
+++ b/spec/acceptance/homes_england/create_new_hif_project_spec.rb
@@ -37,4 +37,30 @@ describe 'Creating a new HIF FileProject' do
     expect(project[:data][:infrastructure]).to eq(project_baseline[:infrastructure])
     expect(project[:data][:financial]).to eq(project_baseline[:financial])
   end
+
+  it 'should have an initial status of draft' do
+    project_baseline = {
+      summary: {
+        project_name: '',
+        description: '',
+        lead_authority: ''
+      },
+      infrastructure: {
+        type: '',
+        description: '',
+        completion_date: '',
+        planning: {
+          submission_estimated: ''
+        }
+      },
+      financial: {
+        total_amount_estimated: ''
+      }
+    }
+    response = get_use_case(:create_new_project).execute(
+      type: 'hif', baseline: project_baseline
+    )
+    project = get_use_case(:find_project).execute(id: response[:id])
+    expect(project[:status]).to eq('Draft')
+  end
 end

--- a/spec/acceptance/homes_england/submit_project_spec.rb
+++ b/spec/acceptance/homes_england/submit_project_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative '../shared_context/dependency_factory'
+
+describe 'Submitting a completed draft project' do
+  include_context 'dependency factory'
+
+  it 'Changes the status to submitted' do
+    project_baseline = {
+      summary: {
+        project_name: '',
+        description: '',
+        lead_authority: ''
+      },
+      infrastructure: {
+        type: '',
+        description: '',
+        completion_date: '',
+        planning: {
+          submission_estimated: ''
+        }
+      },
+      financial: {
+        total_amount_estimated: ''
+      }
+    }
+    response = get_use_case(:create_new_project).execute(
+      type: 'hif', baseline: project_baseline
+    )
+    get_use_case(:submit_project).execute(project_id: response[:id])
+    submitted_project = get_use_case(:find_project).execute(id: response[:id])
+
+    expect(submitted_project[:status]).to eq('Submitted')
+  end
+end

--- a/spec/acceptance/homes_england/update_project_spec.rb
+++ b/spec/acceptance/homes_england/update_project_spec.rb
@@ -32,4 +32,35 @@ describe 'Updating a HIF Project' do
     expect(updated_project[:type]).to eq('hif')
     expect(updated_project[:data][:cats]).to eq('meow')
   end
+
+  context 'updating once submitted' do
+    it 'should change the status back to draft' do
+      project_baseline = {
+        summary: {
+          project_name: 'Cats Protection League',
+          description: 'A new headquarters for all the Cats',
+          lead_authority: 'Made Tech'
+        },
+        infrastructure: {
+          type: 'Cat Bathroom',
+          description: 'Bathroom for Cats',
+          completion_date: '2018-12-25'
+        },
+        financial: {
+          date: '2017-12-25',
+          funded_through_HIF: true
+        }
+      }
+
+      response = get_use_case(:create_new_project).execute(type: 'hif', baseline: project_baseline)
+      get_use_case(:submit_project).execute(project_id: response[:id])
+
+
+      get_use_case(:update_project).execute(id: response[:id], project: { type: 'hif', baseline: { cats: 'meow' } })
+
+      updated_project = get_use_case(:find_project).execute(id: response[:id])
+
+      expect(updated_project[:status]).to eq('Draft')
+    end
+  end
 end

--- a/spec/unit/homes_england/gateway/sequel_project_spec.rb
+++ b/spec/unit/homes_england/gateway/sequel_project_spec.rb
@@ -38,12 +38,14 @@ describe HomesEngland::Gateway::SequelProject do
     context 'updating the project' do
       it 'updates the project' do
         project.data = { dogs: 'woof' }
+        project.status = 'Tree'
         project_gateway.update(id: project_id, project: project)
 
         created_project = project_gateway.find_by(id: project_id)
 
         expect(created_project.type).to eq('Animals')
         expect(created_project.data).to eq(dogs: 'woof')
+        expect(created_project.status).to eq('Tree')
       end
 
       it 'returns successful' do

--- a/spec/unit/homes_england/gateway/sequel_project_spec.rb
+++ b/spec/unit/homes_england/gateway/sequel_project_spec.rb
@@ -31,6 +31,7 @@ describe HomesEngland::Gateway::SequelProject do
 
         expect(created_project.type).to eq('Animals')
         expect(created_project.data).to eq(cats: 'meow')
+        expect(created_project.status).to eq('Draft')
       end
     end
 
@@ -51,6 +52,16 @@ describe HomesEngland::Gateway::SequelProject do
         response = project_gateway.update(id: project_id, project: project)
 
         expect(response).to eq(success: true)
+      end
+    end
+
+    context 'submitting the project' do
+      it 'changes the status to submitted' do
+        project.data = { blank: '' }
+        project_gateway.submit(id: project_id)
+        submitted_project = project_gateway.find_by(id: project_id)
+
+        expect(submitted_project.status).to eq('Submitted')
       end
     end
   end

--- a/spec/unit/homes_england/use_case/create_new_project_spec.rb
+++ b/spec/unit/homes_england/use_case/create_new_project_spec.rb
@@ -19,6 +19,7 @@ describe HomesEngland::UseCase::CreateNewProject do
     let(:project_id) { 0 }
     let(:type) { 'hif' }
     let(:baseline) { { key: 'value' } }
+    let(:status) { '' }
 
     it 'creates the project with populated data' do
       expect(project_gateway).to have_received(:create) do |project|
@@ -30,12 +31,19 @@ describe HomesEngland::UseCase::CreateNewProject do
     it 'returns the id from the gateway' do
       expect(response).to eq(id: 0)
     end
+
+    it 'gives the project a status of draft' do
+      expect(project_gateway).to have_received(:create) do |project|
+        expect(project.status).to eq('Draft')
+      end
+    end
   end
 
   context 'example two' do
     let(:project_id) { 42 }
     let(:type) { 'cats' }
     let(:baseline) { { cat: 'meow' } }
+    let(:status) { '' }
 
     it 'creates the project' do
       expect(project_gateway).to have_received(:create) do |project|
@@ -46,6 +54,12 @@ describe HomesEngland::UseCase::CreateNewProject do
 
     it 'returns the id from the gateway' do
       expect(response).to eq(id: 42)
+    end
+
+    it 'gives the project a status of draft' do
+      expect(project_gateway).to have_received(:create) do |project|
+        expect(project.status).to eq('Draft')
+      end
     end
   end
 end

--- a/spec/unit/homes_england/use_case/find_project_spec.rb
+++ b/spec/unit/homes_england/use_case/find_project_spec.rb
@@ -14,6 +14,7 @@ describe HomesEngland::UseCase::FindProject do
       HomesEngland::Domain::Project.new.tap do |p|
         p.type = 'hif'
         p.data = { dogs: 'woof' }
+        p.status = 'Draft'
       end
     end
     let(:id) { 1 }
@@ -29,6 +30,10 @@ describe HomesEngland::UseCase::FindProject do
     it 'returns a hash containing the projects data' do
       expect(response[:data]).to eq(dogs: 'woof')
     end
+
+    it 'returns a hash containing the projects status' do
+      expect(response[:status]).to eq('Draft')
+    end
   end
 
   context 'example two' do
@@ -36,6 +41,7 @@ describe HomesEngland::UseCase::FindProject do
       HomesEngland::Domain::Project.new.tap do |p|
         p.type = 'abc'
         p.data = { cats: 'meow' }
+        p.status = 'Submitted'
       end
     end
     let(:id) { 5 }
@@ -50,6 +56,10 @@ describe HomesEngland::UseCase::FindProject do
 
     it 'returns a hash containing the projects data' do
       expect(response[:data]).to eq(cats: 'meow')
+    end
+
+    it 'returns a hash containing the projects status' do
+      expect(response[:status]).to eq('Submitted')
     end
   end
 end

--- a/spec/unit/homes_england/use_case/find_project_spec.rb
+++ b/spec/unit/homes_england/use_case/find_project_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rspec'
 
 describe HomesEngland::UseCase::FindProject do

--- a/spec/unit/homes_england/use_case/submit_project_spec.rb
+++ b/spec/unit/homes_england/use_case/submit_project_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe HomesEngland::UseCase::SubmitProject do
+  let(:project_gateway) { spy }
+  let(:use_case) { described_class.new(project_gateway: project_gateway) }
+
+  context 'Example 1' do
+    it 'sets status to submitted upon submit' do
+      use_case.execute(project_id: 1)
+      expect(project_gateway).to have_received(:submit).with(id: 1)
+    end
+  end
+
+  context 'Example 2' do
+    it 'sets status to submitted upon submit' do
+      use_case.execute(project_id: 7)
+      expect(project_gateway).to have_received(:submit).with(id: 7)
+    end
+  end
+end

--- a/spec/unit/homes_england/use_case/update_project_spec.rb
+++ b/spec/unit/homes_england/use_case/update_project_spec.rb
@@ -8,7 +8,7 @@ describe HomesEngland::UseCase::UpdateProject do
 
   context 'example one' do
     let(:project_id) { 42 }
-    let(:updated_project) { { type: 'hif', baseline: { ducks: 'quack' } } }
+    let(:updated_project) { { type: 'hif', baseline: { ducks: 'quack' }, status: 'Draft' } }
 
     context 'given a successful update' do
       let(:project_gateway_spy) do
@@ -32,6 +32,13 @@ describe HomesEngland::UseCase::UpdateProject do
       it 'Should return successful' do
         expect(response).to eq(successful: true)
       end
+
+      it 'Should always pass a draft status to the gateway' do
+        expect(project_gateway_spy).to have_received(:update) do |request|
+          project = request[:project]
+          expect(project.status).to eq('Draft')
+        end
+      end
     end
 
     context 'given an unsuccessful update' do
@@ -47,7 +54,7 @@ describe HomesEngland::UseCase::UpdateProject do
 
   context 'example two' do
     let(:project_id) { 123 }
-    let(:updated_project) { { type: 'abc', baseline: { cows: 'moo' } } }
+    let(:updated_project) { { type: 'abc', baseline: { cows: 'moo' }, status: 'Submitted' } }
 
     context 'given a successful update' do
       let(:project_gateway_spy) do
@@ -70,6 +77,13 @@ describe HomesEngland::UseCase::UpdateProject do
 
       it 'Should return successful' do
         expect(response).to eq(successful: true)
+      end
+
+      it 'Should always pass a draft status to the gateway' do
+        expect(project_gateway_spy).to have_received(:update) do |request|
+          project = request[:project]
+          expect(project.status).to eq('Draft')
+        end
       end
     end
 

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -52,7 +52,7 @@ describe 'Finding a project' do
   context 'with an valid id' do
     context 'example one' do
       let(:project_id) { 42 }
-      let(:project) { { type: 'cat', data: { cats_go: 'meow', dogs_go: 'woof' } } }
+      let(:project) { { type: 'cat', status: 'Draft', data: { cats_go: 'meow', dogs_go: 'woof' } } }
       let(:schema) {  { schema: { cats: 'go meow' } } }
 
 
@@ -71,6 +71,7 @@ describe 'Finding a project' do
       it 'should should have project in body with camel case' do
         response_body = JSON.parse(last_response.body)
         expect(response_body['type']).to eq('cat')
+        expect(response_body['status']).to eq('Draft')
         expect(response_body['data']['catsGo']).to eq('meow')
         expect(response_body['data']['dogsGo']).to eq('woof')
       end
@@ -83,7 +84,7 @@ describe 'Finding a project' do
 
     context 'example two' do
       let(:project_id) { 41 }
-      let(:project) { { type: 'animals', data: { animal_noises: [{ ducks_go: 'quack' }, { cows_go: 'moo' }] } } }
+      let(:project) { { type: 'animals', status: 'Tree', data: { animal_noises: [{ ducks_go: 'quack' }, { cows_go: 'moo' }] } } }
       let(:schema) { { schema: { dogs: 'bark', cats: 'meow' } } }
 
       let(:find_project_spy) { spy(execute: project) }
@@ -103,6 +104,7 @@ describe 'Finding a project' do
       it 'should should have project in body with camel case' do
         response_body = JSON.parse(last_response.body)
         expect(response_body['type']).to eq('animals')
+        expect(response_body['status']).to eq('Tree')
         expect(response_body['data']['animalNoises'][0]['ducksGo']).to eq('quack')
         expect(response_body['data']['animalNoises'][1]['cowsGo']).to eq('moo')
       end

--- a/spec/web_routes/submit_project_spec.rb
+++ b/spec/web_routes/submit_project_spec.rb
@@ -14,31 +14,45 @@ describe 'Submitting a project' do
 
     stub_const(
       'LocalAuthority::UseCase::CheckApiKey',
-      double(new: double(execute: { valid: true }))
+      double(new: check_api_key_spy)
     )
   end
+ 
+  context 'If API key is invalid' do
+    let(:check_api_key_spy) { spy(execute: { valid: false })}
 
-  it 'returns 400 when submitting nothing' do
-    post 'project/submit', nil, 'HTTP_API_KEY' => 'superSecret'
-    expect(last_response.status).to eq(400)
-  end
+    it 'returns 401' do
+      post 'project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'notSoSecret'
 
-  it 'returns 200 when submitting a valid id' do
-    post 'project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
-    expect(last_response.status).to eq(200)
-  end
-
-  context 'example one' do
-    it 'will run submit project use case with id' do
-      post '/project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
-      expect(submit_project_spy).to have_received(:execute).with(project_id: 1)
+      expect(last_response.status).to eq(401)
     end
   end
 
-  context 'example two' do
-    it 'will run submit project use case with id' do
-      post '/project/submit', { project_id: '5' }.to_json, 'HTTP_API_KEY' => 'superSecret'
-      expect(submit_project_spy).to have_received(:execute).with(project_id: 5)
+  context 'If API key is valid' do
+    let(:check_api_key_spy) { spy(execute: { valid: true })}
+
+    it 'returns 400 when submitting nothing' do
+      post 'project/submit', nil, 'HTTP_API_KEY' => 'superSecret'
+      expect(last_response.status).to eq(400)
+    end
+
+    it 'returns 200 when submitting a valid id' do
+      post 'project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+      expect(last_response.status).to eq(200)
+    end
+
+    context 'example one' do
+      it 'will run submit project use case with id' do
+        post '/project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+        expect(submit_project_spy).to have_received(:execute).with(project_id: 1)
+      end
+    end
+
+    context 'example two' do
+      it 'will run submit project use case with id' do
+        post '/project/submit', { project_id: '5' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+        expect(submit_project_spy).to have_received(:execute).with(project_id: 5)
+      end
     end
   end
 end

--- a/spec/web_routes/submit_project_spec.rb
+++ b/spec/web_routes/submit_project_spec.rb
@@ -1,0 +1,44 @@
+# frozen-string-literal: true
+
+require 'rspec'
+require_relative 'delivery_mechanism_spec_helper'
+
+describe 'Submitting a project' do
+  let(:submit_project_spy) { spy(execute: nil) }
+
+  before do
+    stub_const(
+      'HomesEngland::UseCase::SubmitProject',
+      double(new: submit_project_spy)
+    )
+
+    stub_const(
+      'LocalAuthority::UseCase::CheckApiKey',
+      double(new: double(execute: { valid: true }))
+    )
+  end
+
+  it 'returns 400 when submitting nothing' do
+    post 'project/submit', nil, 'HTTP_API_KEY' => 'superSecret'
+    expect(last_response.status).to eq(400)
+  end
+
+  it 'returns 200 when submitting a valid id' do
+    post 'project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+    expect(last_response.status).to eq(200)
+  end
+
+  context 'example one' do
+    it 'will run submit project use case with id' do
+      post '/project/submit', { project_id: '1' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+      expect(submit_project_spy).to have_received(:execute).with(project_id: 1)
+    end
+  end
+
+  context 'example two' do
+    it 'will run submit project use case with id' do
+      post '/project/submit', { project_id: '5' }.to_json, 'HTTP_API_KEY' => 'superSecret'
+      expect(submit_project_spy).to have_received(:execute).with(project_id: 5)
+    end
+  end
+end


### PR DESCRIPTION
You can now have a draft or submitted status on a project to signify when it's finished being edited. 

