### PR TITLE
Outputs forecast tab

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env ash
 
+export OUTPUTS_FORECAST_TAB=yes
+
 _term() {
   echo "Caught SIGTERM signal!"
   kill -TERM "$rack" 2>/dev/null

--- a/db/migrations/8_baseline_integers_to_strings.rb
+++ b/db/migrations/8_baseline_integers_to_strings.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+Sequel.migration do
+  up do
+    projects = from(:projects)
+
+    projects.each do |project|
+      project[:data]['summary']['totalArea'] = project[:data]['summary']['totalArea'].to_s
+      project[:data]['summary']['hifFundingAmount'] = project[:data]['summary']['hifFundingAmount'].to_s
+      project[:data]['summary']['noOfHousingSites'] = project[:data]['summary']['noOfHousingSites'].to_s
+      project[:data]['outputsForecast']['totalUnits'] = project[:data]['outputsForecast']['totalUnits'].to_s
+      project[:data]['infrastructures'].each_with_index do |_infra, i|
+        project[:data]['infrastructures'][i]['landOwnership']['howManySitesToAcquire'] = project[:data]['infrastructures'][i]['landOwnership']['howManySitesToAcquire'].to_s
+      end
+
+      from(:projects).where(id: project[:id]).update(data: project[:data])
+    end
+  end
+
+  down do
+  end
+end

--- a/db/migrator.rb
+++ b/db/migrator.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Migrator
   def initialize
     Sequel.extension :migration
@@ -10,5 +12,8 @@ class Migrator
   def migrate(database)
     Sequel::Migrator.run(database, "#{__dir__}/migrations")
   end
-end
 
+  def migrate_to(database, version)
+    Sequel::Migrator.run(database, "#{__dir__}/migrations", target: version)
+  end
+end

--- a/lib/homes_england/builder/template/templates/hif_template.rb
+++ b/lib/homes_england/builder/template/templates/hif_template.rb
@@ -369,7 +369,7 @@ class HomesEngland::Builder::Template::Templates::HIFTemplate
                                 enum: ['Yes']
                               },
                               howManySitesToAcquire: {
-                                type: 'integer',
+                                type: 'string',
                                 title: 'How many sites?'
                               },
                               toBeAcquiredBy: {
@@ -546,15 +546,15 @@ class HomesEngland::Builder::Template::Templates::HIFTemplate
           enum: ['Greenfield', 'Brownfield', 'Mixed']
         },
         noOfHousingSites: {
-          type: 'integer',
+          type: 'string',
           title: 'Number of housing sites'
         },
         totalArea: {
-          type: 'integer',
+          type: 'string',
           title: 'Total Area (hectares)'
         },
         hifFundingAmount: {
-          type: 'integer',
+          type: 'string',
           title: 'HIF Funding Amount (£)'
         },
         descriptionOfInfrastructure: {
@@ -594,7 +594,7 @@ class HomesEngland::Builder::Template::Templates::HIFTemplate
       title: 'Outputs - Forecast',
       properties: {
         totalUnits: {
-          type: 'integer',
+          type: 'string',
           title: 'Total Units'
         },
         disposalStrategy: {

--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -4,7 +4,7 @@
 class LocalAuthority::Gateway::InMemoryReturnTemplate
   def find_by(type:)
     return nil unless type == 'hif'
-    LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
+    return_template = LocalAuthority::Domain::ReturnTemplate.new.tap do |p|
       p.schema = {
         title: 'HIF Project',
         type: 'object',
@@ -184,7 +184,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                       title: 'Completed date (Calculated)'
                                     }
                                   }
-                                },
+                                }
                               }
                             },
                             {
@@ -1233,7 +1233,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                     period: {
                       title: 'Period',
                       type: 'string',
-                      sourceKey: %i[baseline_data fundingProfiles period], 
+                      sourceKey: %i[baseline_data fundingProfiles period],
                       readonly: true
                     },
                     forecast: {
@@ -1244,31 +1244,31 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         instalment1: {
                           title: '1st Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment1], 
+                          sourceKey: %i[baseline_data fundingProfiles instalment1],
                           readonly: true
                         },
                         instalment2: {
                           title: '2nd Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment2], 
+                          sourceKey: %i[baseline_data fundingProfiles instalment2],
                           readonly: true
                         },
                         instalment3: {
                           title: '3rd Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment3], 
+                          sourceKey: %i[baseline_data fundingProfiles instalment3],
                           readonly: true
                         },
                         instalment4: {
                           title: '4th Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment4], 
+                          sourceKey: %i[baseline_data fundingProfiles instalment4],
                           readonly: true
                         },
                         total: {
                           title: 'Total',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles total], 
+                          sourceKey: %i[baseline_data fundingProfiles total],
                           readonly: true
                         }
                       }
@@ -1309,7 +1309,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                             period: {
                               title: 'Period',
                               type: 'string',
-                              sourceKey: %i[baseline_data fundingProfiles period], 
+                              sourceKey: %i[baseline_data fundingProfiles period],
                               readonly: true
                             },
                             newProfile: {
@@ -1319,23 +1319,23 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                               properties: {
                                 instalment1: {
                                   title: '1st Quarter',
-                                  type: 'string',
+                                  type: 'string'
                                 },
                                 instalment2: {
                                   title: '2nd Quarter',
-                                  type: 'string',
+                                  type: 'string'
                                 },
                                 instalment3: {
                                   title: '3rd Quarter',
-                                  type: 'string',
+                                  type: 'string'
                                 },
                                 instalment4: {
                                   title: '4th Quarter',
-                                  type: 'string',
+                                  type: 'string'
                                 },
                                 total: {
                                   title: 'Total',
-                                  type: 'string',
+                                  type: 'string'
                                 }
                               }
                             }
@@ -1381,7 +1381,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       type: 'string',
                       title: 'Last Return',
                       readonly: true,
-                      sourceKey: %i[return_data fundingPackages hifSpend current],
+                      sourceKey: %i[return_data fundingPackages hifSpend current]
                     }
                   }
                 },
@@ -1397,7 +1397,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                         baseline: {
                           type: 'string',
                           title: 'Baseline Amount',
-                          sourceKey: %i[baseline_data costs infrastructure totalCostOfInfrastructure], 
+                          sourceKey: %i[baseline_data costs infrastructure totalCostOfInfrastructure],
                           readonly: true
                         },
                         current: {
@@ -1417,7 +1417,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                     fundedThroughHIF: {
                       type: 'string',
                       title: 'Totally funded through HIF?',
-                      enum: ['Yes', 'No'],
+                      enum: %w[Yes No],
                       readonly: true,
                       sourceKey: %i[baseline_data costs infrastructure totallyFundedThroughHIF]
                     }
@@ -1451,7 +1451,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                                 risk: {
                                   title: 'Is there a risk?',
                                   type: 'string',
-                                  enum: ['Yes', 'No'],
+                                  enum: %w[Yes No]
                                 },
                                 description: {
                                   title: 'Description of risk',
@@ -1520,30 +1520,194 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
           }
         }
       }
+    end
 
-      p.layout = {
+    return return_template if ENV['OUTPUTS_FORECAST_TAB'].nil?
+
+    return_template.schema[:properties][:outputsForecast] = {
+      title: 'Outputs - Forecast',
+      type: 'object',
+      properties: {
         summary: {
-          project_name: nil,
-          description: nil,
-          lead_authority: nil
-        },
-        infrastructure: {
-          type: nil,
-          description: nil,
-          completion_date: nil,
-          planning: {
-            submission_estimated: nil,
-            submission_actual: nil,
-            submission_delay_reason: nil
+          type: 'object',
+          title: 'Summary',
+          properties: {
+            totalUnits: {
+              type: 'integer',
+              title: 'Total Units',
+              readonly: true,
+              sourceKey: %i[baseline_data outputsForecast totalUnits]
+            },
+            disposalStrategy: {
+              type: 'string',
+              title: 'Disposal Strategy/Critical Path',
+              readonly: true,
+              sourceKey: %i[baseline_data outputsForecast disposalStrategy]
+            }
           }
         },
-        financial: {
-          total_amount_estimated: nil,
-          total_amount_actual: nil,
-          total_amount_changed_reason: nil
+        housingStarts: {
+          type: 'object',
+          title: 'Housing Starts',
+          properties: {
+            baselineAmounts: {
+              title: 'Baseline Amounts',
+              type: 'array',
+              items: {
+                horizontal: true,
+                type: 'object',
+                properties: {
+                  period: {
+                    type: 'string',
+                    title: 'period',
+                    readonly: true,
+                    sourceKey: %i[baseline_data outputsForecast housingForecast period]
+                  },
+                  baselineAmounts: {
+                    type: 'string',
+                    title: 'Baseline Amounts',
+                    readonly: true,
+                    sourceKey: %i[baseline_data outputsForecast housingForecast target]
+                  }
+                }
+              }
+            },
+            anyChanges: {
+              title: 'Any changes to baseline amounts?',
+              type: 'string',
+              enum: %w[Yes No]
+            }
+          },
+          dependencies: {
+            anyChanges: {
+              oneOf: [
+                {
+                  properties: {
+                    anyChanges: { enum: ['Yes'] },
+                    currentReturnAmounts: {
+                      type: 'array',
+                      title: 'Current Return Amounts',
+                      items: {
+                        horizontal: true,
+                        type: 'object',
+                        properties: {
+                          period: {
+                            type: 'string',
+                            title: 'period',
+                            readonly: true,
+                            sourceKey: %i[baseline_data outputsForecast housingForecast period]
+                          },
+                          currentReturnForecast: {
+                            type: 'string',
+                            title: 'Current Return Forecast'
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  properties: {
+                    anyChanges: { enum: ['No'] }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        inYearHousingStarts: {
+          type: 'object',
+          title: 'In year housing starts',
+          properties: {
+            risksToAchieving: {
+              type: 'string',
+              title: 'Risks to achieving'
+            }
+          }
+        },
+        housingCompletions: {
+          type: 'object',
+          title: 'Housing Completions',
+          properties: {
+            baselineAmounts: {
+              title: 'Baseline Amounts',
+              type: 'array',
+              items: {
+                type: 'object',
+                horizontal: true,
+                properties: {
+                  period: {
+                    type: 'string',
+                    title: 'Period',
+                    readonly: true,
+                    sourceKey: %i[baseline_data outputsForecast housingForecast period]
+                  },
+                  baselineAmounts: {
+                    type: 'string',
+                    title: 'Baseline Amounts',
+                    readonly: true,
+                    sourceKey: %i[baseline_data outputsForecast housingForecast housingCompletions]
+                  }
+                }
+              }
+            },
+            anyChanges: {
+              title: 'Any changes to baseline amounts?',
+              type: 'string',
+              enum: %w[Yes No]
+            }
+          },
+          dependencies: {
+            anyChanges: {
+              oneOf: [
+                {
+                  properties: {
+                    anyChanges: { enum: ['Yes'] },
+                    currentReturnAmounts: {
+                      type: 'array',
+                      title: 'Current Return Amounts',
+                      items: {
+                        type: 'object',
+                        horizontal: true,
+                        properties: {
+                          period: {
+                            type: 'string',
+                            title: 'Period',
+                            readonly: true,
+                            sourceKey: %i[baseline_data outputsForecast housingForecast period]
+                          },
+                          currentReturnForecast: {
+                            type: 'string',
+                            title: 'Current Return Forecast'
+                          }
+                        }
+                      }
+                    }
+                  }
+                },
+                {
+                  properties: {
+                    anyChanges: { enum: ['No'] }
+                  }
+                }
+              ]
+            }
+          }
+        },
+        inYearHousingCompletions: {
+          type: 'object',
+          title: 'In year housing completions',
+          properties: {
+            risksToAchieving: {
+              type: 'string',
+              title: 'Risks to achieving'
+            }
+          }
         }
       }
-    end
+    }
+
+    return_template
   end
 
   private

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -58,7 +58,12 @@ describe 'Performing Return on HIF Project' do
   end
 
   before do
+    ENV['OUTPUTS_FORECAST_TAB'] = 'Yes'
     project_id
+  end
+
+  after do
+    ENV['OUTPUTS_FORECAST_TAB'] = nil
   end
 
   it 'should keep track of Returns' do

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -40,7 +40,7 @@
         "laDoesNotControlSite": {
           "whoOwnsSite": "Dave",
           "landAcquisitionRequired": "Yes",
-          "howManySitesToAquire": 10,
+          "howManySitesToAquire": "10",
           "toBeAquiredBy": "LA",
           "summaryOfAcquisitionRequired": "Summary of critical path",
           "allLandAssemblyAchieved": {
@@ -111,5 +111,25 @@
         "private": { "baseline": "5000" }
       }
     }
-  ]
+  ],
+  "outputsForecast": {
+    "summary": {
+      "totalUnits": "10",
+      "disposalStrategy": "Disposal strategy"
+    },
+    "housingStarts": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "100" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    },
+    "housingCompletions": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "0" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    }
+  }
 }

--- a/spec/fixtures/hif_baseline.json
+++ b/spec/fixtures/hif_baseline.json
@@ -6,8 +6,8 @@
     "jointBidAreas": "Made Tech 2",
     "projectDescription": "Descripion of project",
     "greenOrBrownField": "Greenfield",
-    "noOfHousingSites": 10,
-    "totalArea": 10,
+    "noOfHousingSites": "10",
+    "totalArea": "10",
     "hifFundingAmount": "10000",
     "descriptionOfInfrastructure": "An infrastructure",
     "descriptionOfWiderProjectDeliverables": "Wider infrastructure"
@@ -45,7 +45,7 @@
         "underControlOfLA": "Yes",
         "ownershipOfLandOtherThanLA": "Dave",
         "landAcquisitionRequired": "Yes",
-        "howManySitesToAcquire": 10,
+        "howManySitesToAcquire": "10",
         "toBeAcquiredBy": "LA",
         "targetDateToAcquire": "2020-01-01",
         "summaryOfCriticalPath": "Summary of critical path"
@@ -112,7 +112,7 @@
     "s151ProjectLongstopDate": "2020-01-01"
   },
   "outputsForecast": {
-    "totalUnits": 10,
+    "totalUnits": "10",
     "disposalStrategy": "Disposal strategy",
     "housingForecast": [
       {

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -40,7 +40,7 @@
         "laDoesNotControlSite": {
           "whoOwnsSite": "Dave",
           "landAcquisitionRequired": "Yes",
-          "howManySitesToAquire": 10,
+          "howManySitesToAquire": "10",
           "toBeAquiredBy": "LA",
           "summaryOfAcquisitionRequired": "Summary of critical path",
           "allLandAssemblyAchieved": {
@@ -116,5 +116,25 @@
         "private": { "baseline": "5000" }
       }
     }
-  ]
+  ],
+  "outputsForecast": {
+    "summary": {
+      "totalUnits": "10",
+      "disposalStrategy": "Disposal strategy"
+    },
+    "housingStarts": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "100" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    },
+    "housingCompletions": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "0" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    }
+  }
 }

--- a/spec/unit/database_administrator/migration_8_spec.rb
+++ b/spec/unit/database_administrator/migration_8_spec.rb
@@ -1,0 +1,180 @@
+# frozen_string_literal: true
+
+describe 'Migration 8' do
+  include_context 'with database'
+
+  def synchronize_to_non_migrated_version
+    migrator.migrate_to(database, 7)
+  end
+
+  def synchronize_to_migrated_version
+    migrator.migrate_to(database, 8)
+  end
+
+  def create_project(type:, data:)
+    database[:projects].insert(
+      type: type,
+      data: Sequel.pg_json(data)
+    )
+  end
+
+  let(:migrator) { ::Migrator.new }
+
+  before { synchronize_to_non_migrated_version }
+
+  context 'Example one' do
+    let(:baseline_data) do
+      {
+        summary: { noOfHousingSites: 15, totalArea: 12, hifFundingAmount: 10_000 },
+        infrastructures: [
+          {
+            landOwnership: {
+              howManySitesToAcquire: 10
+            }
+          }
+        ],
+        outputsForecast: {
+          totalUnits: 5
+        }
+      }
+    end
+
+    let(:migrated_project_data) { database[:projects].all.first[:data] }
+
+    before do
+      create_project(type: 'hif', data: baseline_data)
+
+      synchronize_to_migrated_version
+    end
+
+    it 'Converts the sites to acquire to a string' do
+      sites_to_acquire = migrated_project_data['infrastructures'][0]['landOwnership']['howManySitesToAcquire']
+
+      expect(sites_to_acquire).to eq('10')
+    end
+
+    it 'Migrates the number of housing sites to a string' do
+      number_of_housing_sites = migrated_project_data['summary']['noOfHousingSites']
+
+      expect(number_of_housing_sites).to eq('15')
+    end
+
+    it 'Migrates the total area to a string' do
+      total_area = migrated_project_data['summary']['totalArea']
+
+      expect(total_area).to eq('12')
+    end
+
+    it 'Migrates the HIF funding amount to a string' do
+      hif_funding_amount = migrated_project_data['summary']['hifFundingAmount']
+
+      expect(hif_funding_amount).to eq('10000')
+    end
+
+    it 'Migrates the outputs forecast total units to a string' do
+      total_units = migrated_project_data['outputsForecast']['totalUnits']
+
+      expect(total_units).to eq('5')
+    end
+  end
+
+  context 'Example two' do
+    let(:project_one_data) do
+      {
+        summary: {
+          noOfHousingSites: 1,
+          totalArea: 101,
+          hifFundingAmount: 20_000
+        },
+        outputsForecast: {
+          totalUnits: 6
+        },
+        infrastructures: [
+          {
+            landOwnership: {
+              howManySitesToAcquire: 50
+            }
+          }
+        ]
+      }
+    end
+
+    let(:project_two_data) do
+      {
+        summary: {
+          noOfHousingSites: 2,
+          totalArea: 102,
+          hifFundingAmount: 30_000
+        },
+        outputsForecast: {
+          totalUnits: 7
+        },
+        infrastructures: [
+          {
+            landOwnership: {
+              howManySitesToAcquire: 100
+            }
+          },
+          {
+            landOwnership: {
+              howManySitesToAcquire: 150
+            }
+          }
+        ]
+      }
+    end
+
+    let(:migrated_project_one_data) { database[:projects].all.first[:data] }
+    let(:migrated_project_two_data) { database[:projects].all.last[:data] }
+
+    before do
+      create_project(type: 'hif', data: project_one_data)
+      create_project(type: 'hif', data: project_two_data)
+
+      synchronize_to_migrated_version
+    end
+
+    it 'Converts the how many sites to acquire to a string' do
+      sites_to_acquire = migrated_project_one_data['infrastructures'][0]['landOwnership']['howManySitesToAcquire']
+      expect(sites_to_acquire).to eq('50')
+
+      sites_to_acquire = migrated_project_two_data['infrastructures'][0]['landOwnership']['howManySitesToAcquire']
+      expect(sites_to_acquire).to eq('100')
+
+      sites_to_acquire = migrated_project_two_data['infrastructures'][1]['landOwnership']['howManySitesToAcquire']
+      expect(sites_to_acquire).to eq('150')
+    end
+
+    it 'Converts the number of housing sites to a string' do
+      number_of_housing_sites = migrated_project_one_data['summary']['noOfHousingSites']
+      expect(number_of_housing_sites).to eq('1')
+
+      number_of_housing_sites = migrated_project_two_data['summary']['noOfHousingSites']
+      expect(number_of_housing_sites).to eq('2')
+    end
+
+    it 'Migrates the total area to a string' do
+      total_area = migrated_project_one_data['summary']['totalArea']
+      expect(total_area).to eq('101')
+
+      total_area = migrated_project_two_data['summary']['totalArea']
+      expect(total_area).to eq('102')
+    end
+
+    it 'Migrates the HIF funding amount to a string' do
+      hif_funding_amount = migrated_project_one_data['summary']['hifFundingAmount']
+      expect(hif_funding_amount).to eq('20000')
+
+      hif_funding_amount = migrated_project_two_data['summary']['hifFundingAmount']
+      expect(hif_funding_amount).to eq('30000')
+    end
+
+    it 'Migrates the outputs forecast total units to a string' do
+      total_units = migrated_project_one_data['outputsForecast']['totalUnits']
+      expect(total_units).to eq('6')
+
+      total_units = migrated_project_two_data['outputsForecast']['totalUnits']
+      expect(total_units).to eq('7')
+    end
+  end
+end

--- a/spec/unit/local_authority/gateway/in_memory_return_template_spec.rb
+++ b/spec/unit/local_authority/gateway/in_memory_return_template_spec.rb
@@ -1,11 +1,29 @@
 describe LocalAuthority::Gateway::InMemoryReturnTemplate do
+  def get_template(type:)
+    described_class.new.find_by(type: type)
+  end
+
   it 'returns a template when given type hif' do
-    template = described_class.new.find_by(type: 'hif')
-    expect(template).not_to be_nil
+    expect(get_template(type: 'hif')).not_to be_nil
   end
 
   it 'returns nil when not given type hif' do
-    template = described_class.new.find_by(type: 'abc')
-    expect(template).to be_nil
+    expect(get_template(type: 'abc')).to be_nil
+  end
+
+  context 'Outputs Forcast Tab' do
+    let(:template) { get_template(type: 'hif') }
+
+    it 'Does not contain the outputs forecast tab when disabled' do
+      expect(template.schema[:properties]).not_to have_key(:outputsForecast)
+    end
+
+    it 'Contains the outputs forecast tab when enabled' do
+      ENV['OUTPUTS_FORECAST_TAB'] = 'Yes'
+
+      expect(template.schema[:properties]).to have_key(:outputsForecast)
+
+      ENV['OUTPUTS_FORECAST_TAB'] = nil
+    end
   end
 end


### PR DESCRIPTION
**WHAT**
- Updates baseline to have strings instead of integers
  - Migrates currently existing baselines
- Adds output forecast to return template

**WHY**
- Population doesn't work with integers, and there's currently no benefit to storing them as not strings
- Outputs forecast tab is required for future returns