### PR TITLE
Notify tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ group :test do
   gem 'rspec'
   gem 'rspec_junit_formatter'
   gem 'timecop'
+  gem 'webmock'
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,12 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
     coderay (1.1.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     diff-lcs (1.3)
     dry-configurable (0.7.0)
       concurrent-ruby (~> 1.0)
@@ -27,6 +31,7 @@ GEM
       guard (~> 2.1)
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
+    hashdiff (0.3.7)
     json_schema (0.19.1)
     jwt (2.1.0)
     listen (3.1.5)
@@ -47,6 +52,7 @@ GEM
     pry (0.11.3)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)
+    public_suffix (3.0.3)
     rack (2.0.5)
     rack-protection (2.0.3)
       rack
@@ -74,6 +80,7 @@ GEM
     rspec_junit_formatter (0.4.1)
       rspec-core (>= 2, < 4, != 2.12.0)
     ruby_dep (1.5.0)
+    safe_yaml (1.0.4)
     sentry-raven (2.7.4)
       faraday (>= 0.7.6, < 1.0)
     sequel (5.10.0)
@@ -86,6 +93,10 @@ GEM
     thor (0.20.0)
     tilt (2.0.8)
     timecop (0.9.1)
+    webmock (3.4.2)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff
 
 PLATFORMS
   ruby
@@ -106,9 +117,10 @@ DEPENDENCIES
   sequel
   sinatra
   timecop
+  webmock
 
 RUBY VERSION
    ruby 2.5.1p57
 
 BUNDLED WITH
-   1.16.4
+   1.16.5

--- a/lib/delivery_mechanism/controllers/post_submit_return.rb
+++ b/lib/delivery_mechanism/controllers/post_submit_return.rb
@@ -1,0 +1,23 @@
+module DeliveryMechanism
+  module Controllers 
+    class PostSubmitReturn
+      def initialize(submit_return:, notify_project_members:)
+        @submit_return = submit_return
+        @notify_project_members = notify_project_members
+      end
+
+      def execute(request, request_hash, response)
+        @submit_return.execute(
+          return_id: request_hash[:return_id].to_i
+        )
+
+        @notify_project_members.execute(
+          project_id: request_hash[:project_id].to_i,
+          url: request_hash[:url]
+        )
+
+        response.status = 200
+      end
+    end
+  end
+end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -83,16 +83,10 @@ module DeliveryMechanism
 
     post '/return/submit' do
       guard_access env, params, request do |request_hash|
-        @dependency_factory.get_use_case(:submit_return).execute(
-          return_id: request_hash[:return_id].to_i
-        )
-
-        @dependency_factory.get_use_case(:notify_project_members).execute(
-          project_id: request_hash[:project_id].to_i,
-          url: request_hash[:url]
-        )
-
-        response.status = 200
+        DeliveryMechanism::Controllers::PostSubmitReturn.new(
+          submit_return: @dependency_factory.get_use_case(:submit_return),
+          notify_project_members: @dependency_factory.get_use_case(:notify_project_members)
+        ).execute(request, request_hash, response)
       end
     end
 

--- a/spec/acceptance/local_authority/notify_project_members_spec.rb
+++ b/spec/acceptance/local_authority/notify_project_members_spec.rb
@@ -1,0 +1,23 @@
+require_relative '../shared_context/dependency_factory'
+require_relative '../../simulator/notification'
+
+describe 'Notifying project members' do
+  include_context 'dependency factory'
+  let(:notification_url) { 'http://meow.cat/' }
+  let(:simulator) { Simulator::Notification.new(self, notification_url) }
+  let(:notification_request) do
+    stub_request(:post, "#{notification_url}v2/notifications/email").to_return(status: 200, body: {}.to_json)
+  end
+  
+  before do
+    ENV['GOV_NOTIFY_API_KEY'] = 'cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe'
+    ENV['GOV_NOTIFY_API_URL'] = notification_url
+    dependency_factory.get_use_case(:add_user_to_project).execute(project_id: 1, email: 'cat@meow.com')
+    simulator.send_notification(to: 'cat@meow.com')
+  end
+
+  it 'Notfies project members' do
+    dependency_factory.get_use_case(:notify_project_members).execute(project_id: 1, url: 'meow.com')
+    simulator.expect_notification_to_have_been_sent_with(access_url: 'meow.com')
+  end
+end

--- a/spec/simulator/notification.rb
+++ b/spec/simulator/notification.rb
@@ -1,0 +1,39 @@
+module Simulator
+  class Notification
+    extend Forwardable
+
+    def_delegators :@test_suite, :expect, :eq, :have_been_made, :hash_including
+
+    def initialize(test_suite, url)
+      @test_suite = test_suite
+      @url = url
+    end
+
+    def send_notification(to:)
+      @stub_request = @test_suite.stub_request(
+        :post,
+        "#{@url}v2/notifications/email").with(
+          body: hash_including(email_address: to)
+        ).to_return(status: 200, body: {}.to_json)
+    end
+
+    def expect_notification_to_have_been_sent_with(access_url:)
+      expect(@stub_request.with do |req|
+        request_body = JSON.parse(req.body)
+        expect(request_body["personalisation"]["access_url"]).to eq(access_url)
+      end).to have_been_made
+    end
+
+    def expect_notification_to_have_been_sent_with_email(access_url:, email_address:)
+      expect(@stub_request.with do |req|
+        request_body = JSON.parse(req.body)
+        expect(request_body["email_address"]).to eq(email_address)
+        expect(request_body["personalisation"]["access_url"]).to eq(access_url)
+      end).to have_been_made
+    end
+
+    def expect_notifier_to_have_been_accessed
+      expect(@stub_request).to have_been_made
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,6 @@
 require 'loader'
 require 'pry'
+require 'webmock/rspec'
 require_relative 'database_context'
 
 RSpec.configure do |config|

--- a/spec/unit/local_authority/gateway/gov_email_notification_gateway_spec.rb
+++ b/spec/unit/local_authority/gateway/gov_email_notification_gateway_spec.rb
@@ -1,6 +1,11 @@
 # frozen_string_literal: true
+require_relative '../../../simulator/notification'
 
 describe LocalAuthority::Gateway::GovEmailNotificationGateway do
+  let(:notification_url) { 'http://meow.cat/' }
+
+  let(:simulator) { Simulator::Notification.new(self, notification_url) }
+
   let(:send_mail_spy) do
     spy(send_email: {})
   end
@@ -10,51 +15,60 @@ describe LocalAuthority::Gateway::GovEmailNotificationGateway do
   end
 
   before do
-    stub_const(
-      'Notifications::Client',
-      notifications_client_spy
-    )
+    ENV['GOV_NOTIFY_API_KEY'] = 'cafe-cafecafe-cafe-cafe-cafe-cafecafecafe-cafecafe-cafe-cafe-cafe-cafecafecafe'
   end
 
   context 'sending a login token' do
     context 'example 1' do
+      let(:notification_request) do
+        stub_request(
+          :post,
+          'https://meow.com/v2/notifications/email'
+        ).to_return(status: 200, body: '{}')
+      end
+
       before do
-        ENV['GOV_NOTIFY_API_KEY'] = 'superSecret'
-        ENV['GOV_NOTIFY_API_URL'] = 'meow.com'
+        notification_request
+        ENV['GOV_NOTIFY_API_URL'] = 'https://meow.com'
+        simulator.send_notification(to: 'cat@cathouse.com')
         described_class.new.send_notification(to: 'cat@cathouse.com', url: 'http://cats.com', access_token: 'CatAccess')
       end
 
       context 'given email address and url' do
-        it 'passes the API key and url to the notifications client' do
-          expect(notifications_client_spy).to have_received(:new).with('superSecret', 'meow.com')
-        end
-
         it 'will run send_email with address and url within personalisation hash' do
-          expect(send_mail_spy).to have_received(:send_email) do |args|
-            expect(args[:email_address]).to eq('cat@cathouse.com')
-            expect(args[:personalisation]).to eq(access_url: 'http://cats.com' + '/?token=CatAccess')
-          end
+          expect(notification_request.with do |req|
+            request_body = JSON.parse(req.body)
+            expect(request_body['email_address']).to eq('cat@cathouse.com')
+            expect(request_body['personalisation']['access_url']).to eq('http://cats.com/?token=CatAccess')
+          end).to have_been_made
         end
       end
     end
 
     context 'example 2' do
+      let(:notification_request) do
+        stub_request(
+          :post,
+          'https://dog.woof/v2/notifications/email'
+        ).to_return(status: 200, body: '{}')
+      end
+
+      let(:notification_url) { 'http://dog.woof/' }
+
       before do
-        ENV['GOV_NOTIFY_API_KEY'] = 'megaSecure'
-        ENV['GOV_NOTIFY_API_URL'] = 'dog.woof'
+        notification_request
+        ENV['GOV_NOTIFY_API_URL'] = 'https://dog.woof'
+        simulator.send_notification(to: 'dog@doghouse.com')
         described_class.new.send_notification(to: 'dog@doghouse.com', url: 'http://dogs.com', access_token: 'DogAccess')
       end
 
       context 'given email address and url' do
-        it 'passes the API key and url to the notifications client' do
-          expect(notifications_client_spy).to have_received(:new).with('megaSecure', 'dog.woof')
-        end
-
         it 'will run send_email with address and url within personalisation hash' do
-          expect(send_mail_spy).to have_received(:send_email) do |args|
-            expect(args[:email_address]).to eq('dog@doghouse.com')
-            expect(args[:personalisation]).to eq(access_url: 'http://dogs.com' + '/?token=DogAccess')
-          end
+          expect(notification_request.with do |req|
+            request_body = JSON.parse(req.body)
+            expect(request_body['email_address']).to eq('dog@doghouse.com')
+            expect(request_body['personalisation']['access_url']).to eq('http://dogs.com/?token=DogAccess')
+          end).to have_been_made
         end
       end
     end
@@ -62,43 +76,40 @@ describe LocalAuthority::Gateway::GovEmailNotificationGateway do
 
   context 'sending a return submission notification' do
     context 'example 1' do
+      let(:notification_url) { 'https://dog.woof/' }
       before do
-        ENV['GOV_NOTIFY_API_KEY'] = 'megaSecure'
-        ENV['GOV_NOTIFY_API_URL'] = 'dog.woof'
+        ENV['GOV_NOTIFY_API_URL'] = 'https://dog.woof'
+        simulator.send_notification(to: 'dog@doghouse.com')
         described_class.new.send_return_notification(to: 'dog@doghouse.com', url: 'http://dogs.com')
       end
 
       context 'given email address and url' do
-        it 'passes the API key and url to the notifications client' do
-          expect(notifications_client_spy).to have_received(:new).with('megaSecure', 'dog.woof')
+        it 'contacts the notification API' do
+          simulator.expect_notifier_to_have_been_accessed
         end
 
         it 'will run send_email with address and url within personalisation hash' do
-          expect(send_mail_spy).to have_received(:send_email) do |args|
-            expect(args[:email_address]).to eq('dog@doghouse.com')
-            expect(args[:personalisation]).to eq(access_url: 'http://dogs.com')
-          end
+          simulator.expect_notification_to_have_been_sent_with_email(access_url: 'http://dogs.com', email_address: 'dog@doghouse.com')
         end
       end
     end
 
     context 'example 2' do
+      let(:notification_url) { 'https://meow.com/' }
+
       before do
-        ENV['GOV_NOTIFY_API_KEY'] = 'superSecret'
-        ENV['GOV_NOTIFY_API_URL'] = 'meow.com'
+        ENV['GOV_NOTIFY_API_URL'] = 'https://meow.com'
+        simulator.send_notification(to: 'cat@cathouse.com')
         described_class.new.send_return_notification(to: 'cat@cathouse.com', url: 'http://cats.com')
       end
 
       context 'given email address and url' do
-        it 'passes the API key and url to the notifications client' do
-          expect(notifications_client_spy).to have_received(:new).with('superSecret', 'meow.com')
+        it 'contacts the notification API' do
+          simulator.expect_notifier_to_have_been_accessed
         end
 
         it 'will run send_email with address and url within personalisation hash' do
-          expect(send_mail_spy).to have_received(:send_email) do |args|
-            expect(args[:email_address]).to eq('cat@cathouse.com')
-            expect(args[:personalisation]).to eq(access_url: 'http://cats.com')
-          end
+          simulator.expect_notification_to_have_been_sent_with_email(access_url: 'http://cats.com', email_address: 'cat@cathouse.com')
         end
       end
     end


### PR DESCRIPTION
What - Adds an acceptance spec for sending notifications to all users as well as refactoring some related tests.  
Why - This is needed to begin adding notifications on project creation (as of this notifications are only done for returns)