### PR TITLE
Change milestone in return template to use milestone, not horizontal

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -752,9 +752,8 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                       title: 'Key Project Milestones',
                       items: {
                         type: 'object',
-                        horizontal: true,
+                        milestone: true,
                         properties: {
-                          # from milestones.target
                           description: {
                             sourceKey: %i[baseline_data infrastructures milestones descriptionOfMilestone],
                             readonly: true,


### PR DESCRIPTION
This PR allows the frontend component for milestones to display instead of the horizontal component.