### PR TITLE
Specify minor version of Ruby in circleci config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/ruby:2.5
+      - image: circleci/ruby:2.5.1
       - image: circleci/postgres:9.4.18-alpine
         environment:
           POSTGRES_USER: circleci


### PR DESCRIPTION
This resolves an issue where circle ci didn't have a minor version specified and so was failing tests on the version of ruby.