### PR TITLE
Add no-cache instruction in header for project find web route

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -190,7 +190,7 @@ module DeliveryMechanism
           data: Common::DeepCamelizeKeys.to_camelized_hash(project[:data]),
           schema: schema
         }.to_json
-        response.headers['Cache-Control'] = 'must-revalidate'
+        response.headers['Cache-Control'] = 'no-cache'
         response.status = 200
       end
     end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -190,6 +190,7 @@ module DeliveryMechanism
           data: Common::DeepCamelizeKeys.to_camelized_hash(project[:data]),
           schema: schema
         }.to_json
+        response.headers['Cache-Control'] = 'must-revalidate'
         response.status = 200
       end
     end

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -23,6 +23,7 @@ module DeliveryMechanism
       schema = @dependency_factory.get_use_case(:get_schema_for_project).execute(type: params['type'])
       return 404 if schema.nil?
       response.body = schema.schema.to_json
+      response.headers['Cache-Control'] = 'no-cache'
       response.status = 200
     end
 
@@ -110,7 +111,7 @@ module DeliveryMechanism
           schema: return_schema,
           type: 'hif'
         }.to_json
-
+        response.headers['Cache-Control'] = 'no-cache'
         response.status = 200
       end
     end
@@ -160,6 +161,7 @@ module DeliveryMechanism
         if base_return.empty?
           response.status = 404
         else
+          response.headers['Cache-Control'] = 'no-cache'
           response.status = 200
           response.body = { baseReturn: base_return[:base_return] }.to_json
         end
@@ -169,6 +171,7 @@ module DeliveryMechanism
     get '/project/:id/returns' do
       guard_access env, params, request do |_|
         returns = @dependency_factory.get_use_case(:get_returns).execute(project_id: params['id'].to_i)
+        response.headers['Cache-Control'] = 'no-cache'
         response.status = returns.empty? ? 404 : 200
         response.body = returns.to_json
       end

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -68,6 +68,10 @@ describe 'Finding a project' do
         expect(last_response.status).to eq(200)
       end
 
+      it 'should pass a cache-control header' do
+        expect(last_response.headers['Cache-Control']).to eq('must-revalidate')
+      end
+
       it 'should should have project in body with camel case' do
         response_body = JSON.parse(last_response.body)
         expect(response_body['type']).to eq('cat')
@@ -99,6 +103,10 @@ describe 'Finding a project' do
 
       it 'should should return 200' do
         expect(last_response.status).to eq(200)
+      end
+
+      it 'should pass a cache-control header' do
+        expect(last_response.headers['Cache-Control']).to eq('must-revalidate')
       end
 
       it 'should should have project in body with camel case' do

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -69,7 +69,7 @@ describe 'Finding a project' do
       end
 
       it 'should pass a cache-control header' do
-        expect(last_response.headers['Cache-Control']).to eq('must-revalidate')
+        expect(last_response.headers['Cache-Control']).to eq('no-cache')
       end
 
       it 'should should have project in body with camel case' do
@@ -106,7 +106,7 @@ describe 'Finding a project' do
       end
 
       it 'should pass a cache-control header' do
-        expect(last_response.headers['Cache-Control']).to eq('must-revalidate')
+        expect(last_response.headers['Cache-Control']).to eq('no-cache')
       end
 
       it 'should should have project in body with camel case' do

--- a/spec/web_routes/get_baseline_schema_spec.rb
+++ b/spec/web_routes/get_baseline_schema_spec.rb
@@ -30,6 +30,10 @@ describe 'Getting a baseline schema' do
         expect(last_response.status).to eq(200)
       end
 
+      it 'should pass a cache-control header' do
+        expect(last_response.headers['Cache-Control']).to eq('no-cache')
+      end
+
       it 'should execute GetSchemaForProject' do
         expect(get_baseline_schema_spy).to have_received(:execute).with(type: type)
       end
@@ -57,6 +61,10 @@ describe 'Getting a baseline schema' do
 
       it 'should return 200' do
         expect(last_response.status).to eq(200)
+      end
+
+      it 'should pass a cache-control header' do
+        expect(last_response.headers['Cache-Control']).to eq('no-cache')
       end
 
       it 'should execute GetSchemaForProject' do

--- a/spec/web_routes/get_return_spec.rb
+++ b/spec/web_routes/get_return_spec.rb
@@ -34,7 +34,7 @@ describe 'Getting a return' do
   end
 
   context 'Given one existing return' do
-    let(:response_body) { JSON.parse(last_response.body) } 
+    let(:response_body) { JSON.parse(last_response.body) }
 
     before do
       get '/return/get?id=0&returnId=1'
@@ -52,6 +52,10 @@ describe 'Getting a return' do
 
     it 'responds with 200 when id found' do
       expect(last_response.status).to eq(200)
+    end
+
+    it 'should pass a cache-control header' do
+      expect(last_response.headers['Cache-Control']).to eq('no-cache')
     end
 
     it 'returns the correct project_id' do

--- a/spec/web_routes/get_returns_spec.rb
+++ b/spec/web_routes/get_returns_spec.rb
@@ -35,6 +35,10 @@ describe 'Getting return history' do
       expect(last_response.status).to eq(200)
     end
 
+    it 'should pass a cache-control header' do
+      expect(last_response.headers['Cache-Control']).to eq('no-cache')
+    end
+
     it 'should respond with an accurate array of hashes' do
       response = Common::DeepSymbolizeKeys.to_symbolized_hash(
         JSON.parse(last_response.body)
@@ -63,6 +67,10 @@ describe 'Getting return history' do
 
     it 'should respond with 200 for a project that exists' do
       expect(last_response.status).to eq(200)
+    end
+
+    it 'should pass a cache-control header' do
+      expect(last_response.headers['Cache-Control']).to eq('no-cache')
     end
 
     it 'should respond with an accurate array of hashes' do


### PR DESCRIPTION
Added an instruction for the find project web route telling the browser not to cache the ajax request.
This should resolve the IE issue where the app doesn't progress from the create project to project summary page correctly.