### PR TITLE
Add usecases for UI Project layer

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -181,7 +181,7 @@ module DeliveryMechanism
     get '/project/find' do
       guard_access env, params, request do |_|
         return 404 if params['id'].nil?
-        project = @dependency_factory.get_use_case(:find_project).execute(id: params['id'].to_i)
+        project = @dependency_factory.get_use_case(:ui_get_project).execute(id: params['id'].to_i)
 
         return 404 if project.nil?
 
@@ -202,7 +202,7 @@ module DeliveryMechanism
     post '/project/create' do
       guard_admin_access env, params, request do |request_hash|
         contoller = DeliveryMechanism::Controllers::PostCreateProject.new(
-          create_new_project: @dependency_factory.get_use_case(:create_new_project)
+          create_new_project: @dependency_factory.get_use_case(:ui_create_project)
         )
 
         content_type 'application/json'
@@ -223,10 +223,10 @@ module DeliveryMechanism
     post '/project/update' do
       guard_access env, params, request do |request_hash|
         if valid_update_request_body(request_hash)
-          use_case = @dependency_factory.get_use_case(:update_project)
+          use_case = @dependency_factory.get_use_case(:ui_update_project)
           update_successful = use_case.execute(
-            project_id: request_hash[:project_id].to_i,
-            project_data: request_hash[:project_data]
+            id: request_hash[:project_id].to_i,
+            data: request_hash[:project_data]
           )[:successful]
           response.status = update_successful ? 200 : 404
         else

--- a/lib/dependency_factory.rb
+++ b/lib/dependency_factory.rb
@@ -16,6 +16,7 @@ class DependencyFactory
     HomesEngland::UseCases.register(self)
     HomesEngland::Gateways.register(self)
     Common::UseCases.register(self)
+    UI::UseCases.register(self)
   end
 
   def define_use_case(use_case, &block)

--- a/lib/ui/namespaces.rb
+++ b/lib/ui/namespaces.rb
@@ -1,0 +1,3 @@
+module UI
+  module UseCase; end
+end

--- a/lib/ui/use_case/create_project.rb
+++ b/lib/ui/use_case/create_project.rb
@@ -1,0 +1,16 @@
+class UI::UseCase::CreateProject
+  def initialize(create_project:)
+    @create_project = create_project
+  end
+
+  def execute(type:, name:, baseline:)
+    created_id = @create_project.execute(
+      type: type, 
+      name: name, 
+      baseline: baseline
+    )[:id]
+
+    { id: created_id }
+  end
+end
+

--- a/lib/ui/use_case/get_project.rb
+++ b/lib/ui/use_case/get_project.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UI::UseCase::GetProject
+  def initialize(find_project:)
+    @find_project = find_project
+  end
+
+  def execute(id:)
+    found_project = @find_project.execute(id: id)
+
+    {
+      name: found_project[:name],
+      type: found_project[:type],
+      data: found_project[:data],
+      status: found_project[:status]
+    }
+  end
+end

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -1,12 +1,13 @@
-class UI::UseCase::UpdateProject
+# frozen_string_literal: true
 
+class UI::UseCase::UpdateProject
   def initialize(update_project:)
     @update_project = update_project
   end
 
   def execute(id:, data:)
     successful = @update_project.execute(
-      project_id: id, 
+      project_id: id,
       project_data: data
     )[:successful]
 

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -1,0 +1,15 @@
+class UI::UseCase::UpdateProject
+
+  def initialize(update_project:)
+    @update_project = update_project
+  end
+
+  def execute(id:, data:)
+    successful = @update_project.execute(
+      project_id: id, 
+      project_data: data
+    )[:successful]
+
+    { successful: successful }
+  end
+end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -13,5 +13,11 @@ class UI::UseCases
         find_project: builder.get_use_case(:find_project)
       )
     end
+
+    builder.define_use_case :ui_update_project do
+      UI::UseCase::UpdateProject.new(
+        update_project: builder.get_use_case(:update_project)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UI::UseCases
+  def self.register(builder)
+    builder.define_use_case :ui_create_project do
+      UI::UseCase::CreateProject.new(
+        create_project: builder.get_use_case(:create_new_project)
+      )
+    end
+
+    builder.define_use_case :ui_get_project do
+      UI::UseCase::GetProject.new(
+        find_project: builder.get_use_case(:find_project)
+      )
+    end
+  end
+end

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -5,21 +5,40 @@ require_relative '../shared_context/dependency_factory'
 describe 'Interacting with a HIF Project from the UI' do
   include_context 'dependency factory'
 
+  def create_project
+    dependency_factory.get_use_case(:ui_create_project).execute(
+      type: 'hif',
+      name: 'Cat Infrastructures',
+      baseline: { cat: 'meow' }
+    )[:id]
+  end
+
+  def get_project(id)
+    dependency_factory.get_use_case(:ui_get_project).execute(
+      id: id
+    )
+  end
+
   context 'Creating the project' do
     it 'Can create the project successfully' do
-      project_id = dependency_factory.get_use_case(:ui_create_project).execute(
-        type: 'hif',
-        name: 'Cat Infrastructures',
-        baseline: { cat: 'meow' }
-      )[:id]
-
-      created_project = dependency_factory.get_use_case(:ui_get_project).execute(
-        id: project_id
-      )
+      project_id = create_project
+      created_project = get_project(project_id)
 
       expect(created_project[:type]).to eq('hif')
       expect(created_project[:name]).to eq('Cat Infrastructures')
       expect(created_project[:data]).to eq(cat: 'meow')
+    end
+  end
+
+  context 'Updating a project' do
+    it 'Can update a created project successfully' do
+      project_id = create_project
+
+      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: { cat: 'mew' })
+
+      updated_project = get_project(project_id)
+
+      expect(updated_project[:data]).to eq(cat: 'mew')
     end
   end
 end

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../shared_context/dependency_factory'
+
+describe 'Interacting with a HIF Project from the UI' do
+  include_context 'dependency factory'
+
+  context 'Creating the project' do
+    it 'Can create the project successfully' do
+      project_id = dependency_factory.get_use_case(:ui_create_project).execute(
+        type: 'hif',
+        name: 'Cat Infrastructures',
+        baseline: { cat: 'meow' }
+      )[:id]
+
+      created_project = dependency_factory.get_use_case(:ui_get_project).execute(
+        id: project_id
+      )
+
+      expect(created_project[:type]).to eq('hif')
+      expect(created_project[:name]).to eq('Cat Infrastructures')
+      expect(created_project[:data]).to eq(cat: 'meow')
+    end
+  end
+end

--- a/spec/unit/ui/use_case/create_project_spec.rb
+++ b/spec/unit/ui/use_case/create_project_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::CreateProject do
+  context 'Example one' do
+    let(:create_project_spy) { spy(execute: { id: 1 }) }
+    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:response) do
+      use_case.execute(type: 'hif', name: 'Cats', baseline: { Cats: 'purr' }) 
+    end
+
+    before do
+      response
+    end
+
+    it 'Calls execute on the create project usecase' do
+      expect(create_project_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on the create project usecase with the project type' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(type: 'hif'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the project name' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(name: 'Cats'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the baseline' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(baseline: { Cats: 'purr' }))
+      )
+    end
+
+    it 'Returns the id from create project' do
+      expect(response).to eq(id: 1)
+    end
+  end
+
+  context 'Example one' do
+    let(:create_project_spy) { spy(execute: { id: 5 }) }
+    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:response) do
+      use_case.execute(type: 'laac', name: 'Dogs', baseline: { doggos: 'woof' })
+    end
+
+    before do
+      response
+    end
+
+    it 'Calls execute on the create project usecase' do
+      expect(create_project_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on the create project usecase with the project type' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(type: 'laac'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the project name' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(name: 'Dogs'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the baseline' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            baseline: { doggos: 'woof' }
+          )
+        )
+      )
+    end
+
+    it 'Returns the id from create project' do
+      expect(response).to eq(id: 5)
+    end
+  end
+end

--- a/spec/unit/ui/use_case/get_project_spec.rb
+++ b/spec/unit/ui/use_case/get_project_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::GetProject do
+  describe 'Example 1' do
+    let(:find_project_spy) do
+      spy(
+        execute: {
+          name: 'Big Buildings',
+          type: 'hif',
+          data: { building1: 'a house' },
+          status: 'Draft'
+        }
+      )
+    end
+    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:response) { use_case.execute(id: 1) }
+
+    before do
+      response
+    end
+
+    it 'Calls execute in the find project use case' do
+      expect(find_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the find project usecase' do
+      expect(find_project_spy).to have_received(:execute).with(id: 1)
+    end
+
+    it 'Return the name from find project' do
+      expect(response[:name]).to eq('Big Buildings')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:type]).to eq('hif')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:data]).to eq(building1: 'a house')
+    end
+
+    it 'Return the status from find project' do
+      expect(response[:status]).to eq('Draft')
+    end
+  end
+
+  describe 'Example 2' do
+    let(:find_project_spy) do
+      spy(
+        execute: {
+          name: 'Big ol woof',
+          type: 'dogs',
+          data: { noise: 'bark' },
+          status: 'Barking'
+        }
+      )
+    end
+    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:response) { use_case.execute(id: 5) }
+
+    before do
+      response
+    end
+
+    it 'Calls execute in the find project use case' do
+      expect(find_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the find project usecase' do
+      expect(find_project_spy).to have_received(:execute).with(id: 5)
+    end
+
+    it 'Return the name from find project' do
+      expect(response[:name]).to eq('Big ol woof')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:type]).to eq('dogs')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:data]).to eq(noise: 'bark')
+    end
+
+    it 'Return the status from find project' do
+      expect(response[:status]).to eq('Barking')
+    end
+  end
+end

--- a/spec/unit/ui/use_case/update_project_spec.rb
+++ b/spec/unit/ui/use_case/update_project_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::UpdateProject do
+  context 'Example one' do
+    let(:update_project_spy) { spy(execute: { successful: true }) }
+    let(:use_case) { described_class.new(update_project: update_project_spy) }
+    let(:response) { use_case.execute(id: 7, data: { cat: 'meow' }) }
+
+    before { response }
+
+    it 'Calls execute on the update project usecase' do
+      expect(update_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the update project use case the project ID' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(hash_including(project_id: 7))
+      )
+    end
+
+    it 'Passes the update project use case the project data' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            project_data: { cat: 'meow' }
+          )
+        )
+      )
+    end
+
+    it 'Returns successful if successful' do
+      expect(response).to eq(successful: true)
+    end
+  end
+
+  context 'Example two' do
+    let(:update_project_spy) { spy(execute: { successful: false }) }
+    let(:use_case) { described_class.new(update_project: update_project_spy) }
+    let(:response) { use_case.execute(id: 2, data: { dog: 'woof' }) }
+
+    before { response }
+
+    it 'Calls execute on the update project usecase' do
+      expect(update_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the update project use case the project ID' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(hash_including(project_id: 2))
+      )
+    end
+
+    it 'Passes the update project use case the project data' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            project_data: { dog: 'woof' }
+          )
+        )
+      )
+    end
+
+    it 'Returns successful if successful' do
+      expect(response).to eq(successful: false)
+    end
+  end
+end

--- a/spec/web_routes/create_new_project_spec.rb
+++ b/spec/web_routes/create_new_project_spec.rb
@@ -21,7 +21,7 @@ describe 'Creating a new project' do
     setup_auth_headers
 
     stub_const(
-      'HomesEngland::UseCase::CreateNewProject',
+      'UI::UseCase::CreateProject',
       double(new: create_new_project_spy)
     )
 

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -13,7 +13,7 @@ describe 'Finding a project' do
 
   before do
     stub_const(
-      'HomesEngland::UseCase::FindProject',
+      'UI::UseCase::GetProject',
       double(new: find_project_spy)
     )
 

--- a/spec/web_routes/update_project_spec.rb
+++ b/spec/web_routes/update_project_spec.rb
@@ -30,13 +30,8 @@ describe 'Updating a project' do
 
   before do
     stub_const(
-      'HomesEngland::UseCase::UpdateProject',
+      'UI::UseCase::UpdateProject',
       double(new: update_project_spy)
-    )
-
-    stub_const(
-      'HomesEngland::UseCase::CreateNewProject',
-      double(new: create_new_project_spy)
     )
 
     stub_const(
@@ -83,8 +78,8 @@ describe 'Updating a project' do
     it 'should update project data for id' do
       expect(update_project_spy).to(
         have_received(:execute).with(
-          project_id: project_id,
-          project_data: { cats: 'quack', dogs: 'baa' }
+          id: project_id,
+          data: { cats: 'quack', dogs: 'baa' }
         )
       )
     end


### PR DESCRIPTION
WHAT 

Adds usecases in the UI namespace for all project data related usecase

WHY

To prepare to add a layer of separation between the UI representation of the data and how it's stored, we've added usecases for UI related actions which can later be extended by adding a conversion usecase