### PR TITLE
Add layer between UI and core for returns

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -181,7 +181,7 @@ module DeliveryMechanism
     get '/project/find' do
       guard_access env, params, request do |_|
         return 404 if params['id'].nil?
-        project = @dependency_factory.get_use_case(:find_project).execute(id: params['id'].to_i)
+        project = @dependency_factory.get_use_case(:ui_get_project).execute(id: params['id'].to_i)
 
         return 404 if project.nil?
 
@@ -202,7 +202,7 @@ module DeliveryMechanism
     post '/project/create' do
       guard_admin_access env, params, request do |request_hash|
         contoller = DeliveryMechanism::Controllers::PostCreateProject.new(
-          create_new_project: @dependency_factory.get_use_case(:create_new_project)
+          create_new_project: @dependency_factory.get_use_case(:ui_create_project)
         )
 
         content_type 'application/json'
@@ -223,10 +223,10 @@ module DeliveryMechanism
     post '/project/update' do
       guard_access env, params, request do |request_hash|
         if valid_update_request_body(request_hash)
-          use_case = @dependency_factory.get_use_case(:update_project)
+          use_case = @dependency_factory.get_use_case(:ui_update_project)
           update_successful = use_case.execute(
-            project_id: request_hash[:project_id].to_i,
-            project_data: request_hash[:project_data]
+            id: request_hash[:project_id].to_i,
+            data: request_hash[:project_data]
           )[:successful]
           response.status = update_successful ? 200 : 404
         else

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -60,7 +60,7 @@ module DeliveryMechanism
           return 400
         end
 
-        @dependency_factory.get_use_case(:soft_update_return).execute(
+        @dependency_factory.get_use_case(:ui_update_return).execute(
           return_id: request_hash[:return_id], return_data: request_hash[:return_data]
         )
 
@@ -70,7 +70,7 @@ module DeliveryMechanism
 
     post '/return/create' do
       guard_access env, params, request do |request_hash|
-        return_id = @dependency_factory.get_use_case(:create_return).execute(
+        return_id = @dependency_factory.get_use_case(:ui_create_return).execute(
           project_id: request_hash[:project_id],
           data: request_hash[:data]
         )
@@ -97,7 +97,7 @@ module DeliveryMechanism
         return 400 if params[:returnId].nil?
         return_id = params[:returnId].to_i
 
-        return_hash = @dependency_factory.get_use_case(:get_return).execute(id: return_id)
+        return_hash = @dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)
 
         return 404 if return_hash.empty?
 
@@ -155,7 +155,7 @@ module DeliveryMechanism
       guard_access env, params, request do |_request_hash|
         return 400 if params['id'].nil?
 
-        base_return = @dependency_factory.get_use_case(:get_base_return).execute(
+        base_return = @dependency_factory.get_use_case(:ui_get_base_return).execute(
           project_id: params['id'].to_i
         )
 
@@ -171,7 +171,7 @@ module DeliveryMechanism
 
     get '/project/:id/returns' do
       guard_access env, params, request do |_|
-        returns = @dependency_factory.get_use_case(:get_returns).execute(project_id: params['id'].to_i)
+        returns = @dependency_factory.get_use_case(:ui_get_returns).execute(project_id: params['id'].to_i)
         response.headers['Cache-Control'] = 'no-cache'
         response.status = returns.empty? ? 404 : 200
         response.body = returns.to_json

--- a/lib/dependency_factory.rb
+++ b/lib/dependency_factory.rb
@@ -16,6 +16,7 @@ class DependencyFactory
     HomesEngland::UseCases.register(self)
     HomesEngland::Gateways.register(self)
     Common::UseCases.register(self)
+    UI::UseCases.register(self)
   end
 
   def define_use_case(use_case, &block)

--- a/lib/ui/namespaces.rb
+++ b/lib/ui/namespaces.rb
@@ -1,0 +1,3 @@
+module UI
+  module UseCase; end
+end

--- a/lib/ui/use_case/create_project.rb
+++ b/lib/ui/use_case/create_project.rb
@@ -1,0 +1,16 @@
+class UI::UseCase::CreateProject
+  def initialize(create_project:)
+    @create_project = create_project
+  end
+
+  def execute(type:, name:, baseline:)
+    created_id = @create_project.execute(
+      type: type, 
+      name: name, 
+      baseline: baseline
+    )[:id]
+
+    { id: created_id }
+  end
+end
+

--- a/lib/ui/use_case/create_return.rb
+++ b/lib/ui/use_case/create_return.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UI::UseCase::CreateReturn
+  def initialize(create_return:)
+    @create_return = create_return
+  end
+
+  def execute(project_id:, data:)
+    return_id = @create_return.execute(project_id: project_id, data: data)[:id]
+
+    { id: return_id }
+  end
+end

--- a/lib/ui/use_case/get_base_return.rb
+++ b/lib/ui/use_case/get_base_return.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+class UI::UseCase::GetBaseReturn
+  def initialize(get_base_return:)
+    @get_base_return = get_base_return
+  end
+
+  def execute(project_id:)
+    base_return = @get_base_return.execute(project_id: project_id)[:base_return]
+
+    { base_return: base_return }
+  end
+end

--- a/lib/ui/use_case/get_project.rb
+++ b/lib/ui/use_case/get_project.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+class UI::UseCase::GetProject
+  def initialize(find_project:)
+    @find_project = find_project
+  end
+
+  def execute(id:)
+    found_project = @find_project.execute(id: id)
+
+    {
+      name: found_project[:name],
+      type: found_project[:type],
+      data: found_project[:data],
+      status: found_project[:status]
+    }
+  end
+end

--- a/lib/ui/use_case/get_return.rb
+++ b/lib/ui/use_case/get_return.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class UI::UseCase::GetReturn
+  def initialize(get_return:)
+    @get_return = get_return
+  end
+
+  def execute(id:)
+    found_return = @get_return.execute(id: id)
+
+    {
+      id: found_return[:id],
+      type: found_return[:type],
+      project_id: found_return[:project_id],
+      status: found_return[:status],
+      updates: found_return[:updates]
+    }
+  end
+end

--- a/lib/ui/use_case/get_returns.rb
+++ b/lib/ui/use_case/get_returns.rb
@@ -1,0 +1,11 @@
+class UI::UseCase::GetReturns
+  def initialize(get_returns:)
+    @get_returns = get_returns
+  end
+
+  def execute(project_id:)
+    found_returns = @get_returns.execute(project_id: project_id)[:returns]
+
+    { returns: found_returns }
+  end
+end

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -1,12 +1,13 @@
-class UI::UseCase::UpdateProject
+# frozen_string_literal: true
 
+class UI::UseCase::UpdateProject
   def initialize(update_project:)
     @update_project = update_project
   end
 
   def execute(id:, data:)
     successful = @update_project.execute(
-      project_id: id, 
+      project_id: id,
       project_data: data
     )[:successful]
 

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -1,0 +1,15 @@
+class UI::UseCase::UpdateProject
+
+  def initialize(update_project:)
+    @update_project = update_project
+  end
+
+  def execute(id:, data:)
+    successful = @update_project.execute(
+      project_id: id, 
+      project_data: data
+    )[:successful]
+
+    { successful: successful }
+  end
+end

--- a/lib/ui/use_case/update_return.rb
+++ b/lib/ui/use_case/update_return.rb
@@ -1,0 +1,11 @@
+class UI::UseCase::UpdateReturn
+  def initialize(update_return:)
+    @update_return = update_return
+  end
+
+  def execute(return_id:, return_data:)
+    @update_return.execute(return_id: return_id, return_data: return_data)
+
+    {}
+  end
+end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -25,5 +25,11 @@ class UI::UseCases
         get_base_return: builder.get_use_case(:get_base_return)
       )
     end
+
+    builder.define_use_case :ui_create_return do
+      UI::UseCase::CreateReturn.new(
+        create_return: builder.get_use_case(:create_return)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -43,5 +43,11 @@ class UI::UseCases
         get_return: builder.get_use_case(:get_return)
       )
     end
+
+    builder.define_use_case :ui_get_returns do
+      UI::UseCase::GetReturns.new(
+        get_returns: builder.get_use_case(:get_returns)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -31,5 +31,11 @@ class UI::UseCases
         create_return: builder.get_use_case(:create_return)
       )
     end
+
+    builder.define_use_case :ui_update_return do
+      UI::UseCase::UpdateReturn.new(
+        update_return: builder.get_use_case(:soft_update_return)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -13,5 +13,11 @@ class UI::UseCases
         find_project: builder.get_use_case(:find_project)
       )
     end
+
+    builder.define_use_case :ui_update_project do
+      UI::UseCase::UpdateProject.new(
+        update_project: builder.get_use_case(:update_project)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class UI::UseCases
+  def self.register(builder)
+    builder.define_use_case :ui_create_project do
+      UI::UseCase::CreateProject.new(
+        create_project: builder.get_use_case(:create_new_project)
+      )
+    end
+
+    builder.define_use_case :ui_get_project do
+      UI::UseCase::GetProject.new(
+        find_project: builder.get_use_case(:find_project)
+      )
+    end
+  end
+end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -19,5 +19,11 @@ class UI::UseCases
         update_project: builder.get_use_case(:update_project)
       )
     end
+
+    builder.define_use_case :ui_get_base_return do
+      UI::UseCase::GetBaseReturn.new(
+        get_base_return: builder.get_use_case(:get_base_return)
+      )
+    end
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -37,5 +37,11 @@ class UI::UseCases
         update_return: builder.get_use_case(:soft_update_return)
       )
     end
+
+    builder.define_use_case :ui_get_return do
+      UI::UseCase::GetReturn.new(
+        get_return: builder.get_use_case(:get_return)
+      )
+    end
   end
 end

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -5,21 +5,40 @@ require_relative '../shared_context/dependency_factory'
 describe 'Interacting with a HIF Project from the UI' do
   include_context 'dependency factory'
 
+  def create_project
+    dependency_factory.get_use_case(:ui_create_project).execute(
+      type: 'hif',
+      name: 'Cat Infrastructures',
+      baseline: { cat: 'meow' }
+    )[:id]
+  end
+
+  def get_project(id)
+    dependency_factory.get_use_case(:ui_get_project).execute(
+      id: id
+    )
+  end
+
   context 'Creating the project' do
     it 'Can create the project successfully' do
-      project_id = dependency_factory.get_use_case(:ui_create_project).execute(
-        type: 'hif',
-        name: 'Cat Infrastructures',
-        baseline: { cat: 'meow' }
-      )[:id]
-
-      created_project = dependency_factory.get_use_case(:ui_get_project).execute(
-        id: project_id
-      )
+      project_id = create_project
+      created_project = get_project(project_id)
 
       expect(created_project[:type]).to eq('hif')
       expect(created_project[:name]).to eq('Cat Infrastructures')
       expect(created_project[:data]).to eq(cat: 'meow')
+    end
+  end
+
+  context 'Updating a project' do
+    it 'Can update a created project successfully' do
+      project_id = create_project
+
+      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: { cat: 'mew' })
+
+      updated_project = get_project(project_id)
+
+      expect(updated_project[:data]).to eq(cat: 'mew')
     end
   end
 end

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+require_relative '../shared_context/dependency_factory'
+
+describe 'Interacting with a HIF Project from the UI' do
+  include_context 'dependency factory'
+
+  context 'Creating the project' do
+    it 'Can create the project successfully' do
+      project_id = dependency_factory.get_use_case(:ui_create_project).execute(
+        type: 'hif',
+        name: 'Cat Infrastructures',
+        baseline: { cat: 'meow' }
+      )[:id]
+
+      created_project = dependency_factory.get_use_case(:ui_get_project).execute(
+        id: project_id
+      )
+
+      expect(created_project[:type]).to eq('hif')
+      expect(created_project[:name]).to eq('Cat Infrastructures')
+      expect(created_project[:data]).to eq(cat: 'meow')
+    end
+  end
+end

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -36,7 +36,7 @@ describe 'Interacting with a HIF Return from the UI' do
       return_id = dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: return_data)[:id]
       return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:status] = 'Delayed'
       return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
-      dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, data: return_data)
+      dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, return_data: return_data)
 
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(return_id: return_id)
 

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -31,11 +31,11 @@ describe 'Interacting with a HIF Return from the UI' do
 
   context 'Creating a return' do
     it 'Allows you to create and view a return' do
-      base_return = get_use_case(:ui_get_base_return).execute(project_id: project_id)
-      return_data = base_return.dup
+      base_return = get_use_case(:ui_get_base_return).execute(project_id: project_id)[:base_return]
+      return_data = base_return[:data].dup
       return_id = dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: return_data)[:id]
-      return_data[:infrastructures][:planning][:outlinePlanning][:planningSubmitted][:status] = 'Delayed'
-      return_data[:infrastructures][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
+      return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:status] = 'Delayed'
+      return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
       dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, data: return_data)
 
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(return_id: return_id)

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -5,6 +5,23 @@ require_relative '../shared_context/dependency_factory'
 describe 'Interacting with a HIF Return from the UI' do
   include_context 'dependency factory'
 
+  before do
+    ENV['OUTPUTS_FORECAST_TAB'] = 'Yes'
+    ENV['CONFIRMATION_TAB'] = 'Yes'
+    ENV['S151_TAB'] = 'Yes'
+    ENV['RM_MONTHLY_CATCHUP_TAB'] = 'Yes'
+    ENV['OUTPUTS_ACTUALS_TAB'] = 'Yes'
+    project_id
+  end
+
+  after do
+    ENV['OUTPUTS_FORECAST_TAB'] = nil
+    ENV['CONFIRMATION_TAB'] = nil
+    ENV['S151_TAB'] = nil
+    ENV['RM_MONTHLY_CATCHUP_TAB'] = nil
+    ENV['OUTPUTS_ACTUALS_TAB'] = nil
+  end
+
   let(:project_id) { create_project }
   let(:hif_baseline) do
     JSON.parse(
@@ -14,7 +31,7 @@ describe 'Interacting with a HIF Return from the UI' do
   end
   let(:expected_updated_return) do
     JSON.parse(
-      File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
+      File.open("#{__dir__}/../../fixtures/hif_updated_return.json").read,
       symbolize_names: true
     )
   end
@@ -27,8 +44,6 @@ describe 'Interacting with a HIF Return from the UI' do
     )[:id]
   end
 
-  before { project_id }
-
   context 'Creating a return' do
     it 'Allows you to create and view a return' do
       base_return = get_use_case(:ui_get_base_return).execute(project_id: project_id)[:base_return]
@@ -38,7 +53,7 @@ describe 'Interacting with a HIF Return from the UI' do
       return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
       dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, return_data: return_data)
 
-      created_return = dependency_factory.get_use_case(:ui_get_return).execute(return_id: return_id)
+      created_return = dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)[:updates].last
 
       expect(created_return).to eq(expected_updated_return)
     end

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require_relative '../shared_context/dependency_factory'
+
+describe 'Interacting with a HIF Return from the UI' do
+  include_context 'dependency factory'
+
+  let(:project_id) { create_project }
+  let(:hif_baseline) do
+    JSON.parse(
+      File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+  let(:expected_updated_return) do
+    JSON.parse(
+      File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
+  def create_project
+    dependency_factory.get_use_case(:ui_create_project).execute(
+      type: 'hif',
+      name: 'Cat Infrastructures',
+      baseline: hif_baseline
+    )[:id]
+  end
+
+  before { project_id }
+
+  context 'Creating a return' do
+    it 'Allows you to create and view a return' do
+      base_return = get_use_case(:ui_get_base_return).execute(project_id: project_id)
+      return_data = base_return.dup
+      return_id = dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: return_data)[:id]
+      return_data[:infrastructures][:planning][:outlinePlanning][:planningSubmitted][:status] = 'Delayed'
+      return_data[:infrastructures][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
+      dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, data: return_data)
+
+      created_return = dependency_factory.get_use_case(:ui_get_return).execute(return_id: return_id)
+
+      expect(created_return).to eq(expected_updated_return)
+    end
+  end
+end

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -57,5 +57,20 @@ describe 'Interacting with a HIF Return from the UI' do
 
       expect(created_return).to eq(expected_updated_return)
     end
+
+    it 'Allows you to view multiple created returns' do
+      base_return = get_use_case(:ui_get_base_return).execute(project_id: project_id)[:base_return]
+      return_data = base_return[:data].dup
+      dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: return_data)[:id]
+      dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: return_data)[:id]
+
+      created_returns = dependency_factory.get_use_case(:ui_get_returns).execute(project_id: project_id)[:returns]
+
+      created_return_one = created_returns[0][:updates][0]
+      created_return_two = created_returns[1][:updates][0]
+
+      expect(created_return_one).to eq(return_data)
+      expect(created_return_two).to eq(return_data)
+    end
   end
 end

--- a/spec/fixtures/hif_updated_return.json
+++ b/spec/fixtures/hif_updated_return.json
@@ -1,0 +1,169 @@
+{
+  "infrastructures": [
+    {
+      "summary": {
+        "type": "A House",
+        "description": "A house of cats"
+      },
+      "planning": {
+        "outlinePlanning": {
+          "baselineOutlinePlanningPermissionGranted": "No",
+          "baselineSummaryOfCriticalPath": "Summary of critical path",
+          "planningSubmitted": {
+            "baseline": "2020-01-01",
+            "status": "Delayed",
+            "reason": "Distracted by kittens"
+          },
+          "planningGranted": {
+            "baseline": "2020-02-01"
+          }
+        },
+        "fullPlanning": {
+          "fullPlanningPermissionGranted": "No",
+          "fullPlanningPermissionSummaryOfCriticalPath": "Summary of critical path",
+          "submitted": {
+            "baseline": "2020-03-01"
+          },
+          "granted": {
+            "baseline": "2020-04-01"
+          }
+        },
+        "section106": {
+          "s106Requirement": "Yes",
+          "s106SummaryOfRequirement": "Required",
+          "statutoryConsents": {
+            "anyStatutoryConsents": "Yes",
+            "statutoryConsents": [{ "baselineCompletion": "2020-01-01" }]
+          }
+        },
+        "planningNotGranted": {
+          "fieldOne": {
+            "varianceCalculations": {
+              "varianceAgainstLastReturn": {
+                "varianceLastReturnFullPlanningPermissionSubmitted": null
+              }
+            }
+          }
+        }
+      },
+      "landOwnership": {
+        "laHasControlOfSite": "Yes",
+        "laDoesNotControlSite": {
+          "whoOwnsSite": "Dave",
+          "landAcquisitionRequired": "Yes",
+          "howManySitesToAquire": "10",
+          "toBeAquiredBy": "LA",
+          "summaryOfAcquisitionRequired": "Summary of critical path",
+          "allLandAssemblyAchieved": {
+            "baseline": "2020-01-01"
+          }
+        }
+      },
+      "procurement": {
+        "contractorProcured": "Yes",
+        "nameOfContractor": "Steve",
+        "summaryOfCriticalPath": "Summary of critical meow",
+        "procurementBaselineCompletion": "2020-01-01"
+      },
+      "milestones": {
+        "keyMilestones": [
+          {
+            "description": "Milestone One",
+            "milestoneBaselineCompletion": "2020-01-01",
+            "milestoneSummaryOfCriticalPath": "Summary of critical path"
+          }
+        ],
+        "expectedInfrastructureStartOnSite": {
+          "baseline": "2020-01-01"
+        },
+        "expectedCompletionDateOfInfra": {
+          "baseline": "2020-01-01"
+        }
+      },
+      "risks": {
+        "baselineRisks": [
+          {
+            "riskBaselineRisk": "Risk one",
+            "riskBaselineImpact": "High",
+            "riskBaselineLikelihood": "High",
+            "riskBaselineMitigationsInPlace": "Do not do the thing"
+          }
+        ]
+      }
+    }
+  ],
+  "fundingProfiles": {
+    "totalHIFGrant": "10000",
+    "fundingRequest": [
+      {
+        "period": "2019/2020",
+        "forecast": {
+          "instalment1": "1000",
+          "instalment2": "1000",
+          "instalment3": "1000",
+          "instalment4": "1000",
+          "total": "4000"
+        }
+      }
+    ],
+    "requestedProfiles": [{ "period": "2019/2020" }]
+  },
+  "fundingPackages": [
+    {
+      "fundingStack": {
+        "hifSpend": {
+          "baseline": "10000"
+        },
+        "totalCost": {
+          "baseline": "20000"
+        },
+        "fundedThroughHIF": "No",
+        "descriptionOfFundingStack": "Funding stack description",
+        "public": { "baseline": "5000" },
+        "private": { "baseline": "5000" }
+      }
+    }
+  ],
+  "outputsForecast": {
+    "summary": {
+      "totalUnits": "10",
+      "disposalStrategy": "Disposal strategy"
+    },
+    "housingStarts": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "100" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    },
+    "housingCompletions": {
+      "baselineAmounts": [
+        { "period": "18/19", "baselineAmounts": "0" },
+        { "period": "19/20", "baselineAmounts": "50" }
+      ],
+      "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    }
+  },
+  "outputsActuals": {
+    "localAuthority": ["Local Authority"],
+    "noOfUnits": ["123"]
+  },
+  "s151Confirmation": {
+    "hifFunding": {
+      "hifFundingProfile": [
+        {
+          "period": "2019/2020",
+          "instalment1": "1000",
+          "instalment2": "1000",
+          "instalment3": "1000",
+          "instalment4": "1000",
+          "total": "4000"
+        }
+      ]
+    },
+    "submission": {
+      "hifFundingEndDate": "2020-01-01",
+      "projectLongstopDate": "2020-01-01"
+    }
+  }
+}

--- a/spec/unit/database_administrator/migration_8_spec.rb
+++ b/spec/unit/database_administrator/migration_8_spec.rb
@@ -124,13 +124,15 @@ describe 'Migration 8' do
       }
     end
 
-    let(:migrated_project_one_data) { database[:projects].all.first[:data] }
-    let(:migrated_project_two_data) { database[:projects].all.last[:data] }
+    let(:project_one_id) { create_project(type: 'hif', data: project_one_data) }
+    let(:project_two_id) { create_project(type: 'hif', data: project_two_data) }
+
+    let(:migrated_project_one_data) { database[:projects].where(id: project_one_id).all.first[:data] }
+    let(:migrated_project_two_data) { database[:projects].where(id: project_two_id).all.first[:data] }
 
     before do
-      create_project(type: 'hif', data: project_one_data)
-      create_project(type: 'hif', data: project_two_data)
-
+      project_one_id
+      project_two_id
       synchronize_to_migrated_version
     end
 

--- a/spec/unit/ui/use_case/create_project_spec.rb
+++ b/spec/unit/ui/use_case/create_project_spec.rb
@@ -39,7 +39,7 @@ describe UI::UseCase::CreateProject do
     end
   end
 
-  context 'Example one' do
+  context 'Example two' do
     let(:create_project_spy) { spy(execute: { id: 5 }) }
     let(:use_case) { described_class.new(create_project: create_project_spy) }
     let(:response) do

--- a/spec/unit/ui/use_case/create_project_spec.rb
+++ b/spec/unit/ui/use_case/create_project_spec.rb
@@ -1,0 +1,83 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::CreateProject do
+  context 'Example one' do
+    let(:create_project_spy) { spy(execute: { id: 1 }) }
+    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:response) do
+      use_case.execute(type: 'hif', name: 'Cats', baseline: { Cats: 'purr' }) 
+    end
+
+    before do
+      response
+    end
+
+    it 'Calls execute on the create project usecase' do
+      expect(create_project_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on the create project usecase with the project type' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(type: 'hif'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the project name' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(name: 'Cats'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the baseline' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(baseline: { Cats: 'purr' }))
+      )
+    end
+
+    it 'Returns the id from create project' do
+      expect(response).to eq(id: 1)
+    end
+  end
+
+  context 'Example one' do
+    let(:create_project_spy) { spy(execute: { id: 5 }) }
+    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:response) do
+      use_case.execute(type: 'laac', name: 'Dogs', baseline: { doggos: 'woof' })
+    end
+
+    before do
+      response
+    end
+
+    it 'Calls execute on the create project usecase' do
+      expect(create_project_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on the create project usecase with the project type' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(type: 'laac'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the project name' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(hash_including(name: 'Dogs'))
+      )
+    end
+
+    it 'Calls execute on the create project usecase with the baseline' do
+      expect(create_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            baseline: { doggos: 'woof' }
+          )
+        )
+      )
+    end
+
+    it 'Returns the id from create project' do
+      expect(response).to eq(id: 5)
+    end
+  end
+end

--- a/spec/unit/ui/use_case/create_return_spec.rb
+++ b/spec/unit/ui/use_case/create_return_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::CreateReturn do
+  describe 'Example one' do
+    let(:create_return_spy) { spy(execute: { id: 1 }) }
+    let(:use_case) { described_class.new(create_return: create_return_spy) }
+    let(:response) { use_case.execute(project_id: 3, data: { my_new_return: 'data' }) }
+
+    before { response }
+
+    it 'Calls the create return use case' do
+      expect(create_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to create return use case' do
+      expect(create_return_spy).to(
+        have_received(:execute).with(hash_including(project_id: 3))
+      )
+    end
+
+    it 'Passes the project data to create return use case' do
+      expect(create_return_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            data: { my_new_return: 'data' }
+          )
+        )
+      )
+    end
+
+    it 'Returns the created return id' do
+      expect(response).to eq(id: 1)
+    end
+  end
+
+  describe 'Example two' do
+    let(:create_return_spy) { spy(execute: { id: 5 }) }
+    let(:use_case) { described_class.new(create_return: create_return_spy) }
+    let(:response) { use_case.execute(project_id: 8, data: { cats: 'say meow' }) }
+
+    before { response }
+
+    it 'Calls the create return use case' do
+      expect(create_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to create return use case' do
+      expect(create_return_spy).to(
+        have_received(:execute).with(hash_including(project_id: 8))
+      )
+    end
+
+    it 'Passes the project data to create return use case' do
+      expect(create_return_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            data: { cats: 'say meow' }
+          )
+        )
+      )
+    end
+
+    it 'Returns the created return id' do
+      expect(response).to eq(id: 5)
+    end
+  end
+end

--- a/spec/unit/ui/use_case/get_base_return_spec.rb
+++ b/spec/unit/ui/use_case/get_base_return_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::GetBaseReturn do
+  context 'Example one' do
+    let(:get_base_return_spy) { spy(execute: { base_return: { cat: 'meow' } }) }
+    let(:use_case) { described_class.new(get_base_return: get_base_return_spy) }
+    let(:response) { use_case.execute(project_id: 4) }
+
+    before { response }
+
+    it 'Calls execute on the get base return usecase' do
+      expect(get_base_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to get base return' do
+      expect(get_base_return_spy).to have_received(:execute).with(project_id: 4)
+    end
+
+    it 'Returns the basereturn from get base return' do
+      expect(response).to eq(base_return: { cat: 'meow' })
+    end
+  end
+
+  context 'Example two' do
+    let(:get_base_return_spy) { spy(execute: { base_return: { dog: 'woof' } }) }
+    let(:use_case) { described_class.new(get_base_return: get_base_return_spy) }
+    let(:response) { use_case.execute(project_id: 7) }
+
+    before { response }
+
+    it 'Calls execute on the get base return usecase' do
+      expect(get_base_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to get base return' do
+      expect(get_base_return_spy).to have_received(:execute).with(project_id: 7)
+    end
+
+    it 'Returns the basereturn from get base return' do
+      expect(response).to eq(base_return: { dog: 'woof' })
+    end
+  end
+end

--- a/spec/unit/ui/use_case/get_project_spec.rb
+++ b/spec/unit/ui/use_case/get_project_spec.rb
@@ -1,0 +1,89 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::GetProject do
+  describe 'Example 1' do
+    let(:find_project_spy) do
+      spy(
+        execute: {
+          name: 'Big Buildings',
+          type: 'hif',
+          data: { building1: 'a house' },
+          status: 'Draft'
+        }
+      )
+    end
+    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:response) { use_case.execute(id: 1) }
+
+    before do
+      response
+    end
+
+    it 'Calls execute in the find project use case' do
+      expect(find_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the find project usecase' do
+      expect(find_project_spy).to have_received(:execute).with(id: 1)
+    end
+
+    it 'Return the name from find project' do
+      expect(response[:name]).to eq('Big Buildings')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:type]).to eq('hif')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:data]).to eq(building1: 'a house')
+    end
+
+    it 'Return the status from find project' do
+      expect(response[:status]).to eq('Draft')
+    end
+  end
+
+  describe 'Example 2' do
+    let(:find_project_spy) do
+      spy(
+        execute: {
+          name: 'Big ol woof',
+          type: 'dogs',
+          data: { noise: 'bark' },
+          status: 'Barking'
+        }
+      )
+    end
+    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:response) { use_case.execute(id: 5) }
+
+    before do
+      response
+    end
+
+    it 'Calls execute in the find project use case' do
+      expect(find_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the find project usecase' do
+      expect(find_project_spy).to have_received(:execute).with(id: 5)
+    end
+
+    it 'Return the name from find project' do
+      expect(response[:name]).to eq('Big ol woof')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:type]).to eq('dogs')
+    end
+
+    it 'Return the type from find project' do
+      expect(response[:data]).to eq(noise: 'bark')
+    end
+
+    it 'Return the status from find project' do
+      expect(response[:status]).to eq('Barking')
+    end
+  end
+end

--- a/spec/unit/ui/use_case/get_return_spec.rb
+++ b/spec/unit/ui/use_case/get_return_spec.rb
@@ -1,0 +1,95 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::GetReturn do
+  describe 'Example one' do
+    let(:get_return_spy) do
+      spy(
+        execute: {
+          id: 1,
+          type: 'cat',
+          project_id: 2,
+          status: 'Meow',
+          updates: [{ dog: 'woof' }]
+        }
+      )
+    end
+    let(:use_case) { described_class.new(get_return: get_return_spy) }
+    let(:response) { use_case.execute(id: 1) }
+
+    before { response }
+
+    it 'Calls the get return use case' do
+      expect(get_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the get return usecase' do
+      expect(get_return_spy).to have_received(:execute).with(id: 1)
+    end
+
+    it 'Returns the ID from the get return use case' do
+      expect(response[:id]).to eq(1)
+    end
+
+    it 'Returns the type from the get return use case' do
+      expect(response[:type]).to eq('cat')
+    end
+
+    it 'Returns the project id from the get return use case' do
+      expect(response[:project_id]).to eq(2)
+    end
+
+    it 'Returns the status from the get return use case' do
+      expect(response[:status]).to eq('Meow')
+    end
+
+    it 'Returns the updates from the get return use case' do
+      expect(response[:updates]).to eq([{ dog: 'woof' }])
+    end
+  end
+
+  describe 'Example two' do
+    let(:get_return_spy) do
+      spy(
+        execute: {
+          id: 5,
+          type: 'dog',
+          project_id: 7,
+          status: 'Woof',
+          updates: [{ duck: 'quack' }]
+        }
+      )
+    end
+    let(:use_case) { described_class.new(get_return: get_return_spy) }
+    let(:response) { use_case.execute(id: 5) }
+
+    before { response }
+
+    it 'Calls the get return use case' do
+      expect(get_return_spy).to have_received(:execute)
+    end
+
+    it 'Passes the ID to the get return usecase' do
+      expect(get_return_spy).to have_received(:execute).with(id: 5)
+    end
+
+    it 'Returns the ID from the get return use case' do
+      expect(response[:id]).to eq(5)
+    end
+
+    it 'Returns the type from the get return use case' do
+      expect(response[:type]).to eq('dog')
+    end
+
+    it 'Returns the project id from the get return use case' do
+      expect(response[:project_id]).to eq(7)
+    end
+
+    it 'Returns the status from the get return use case' do
+      expect(response[:status]).to eq('Woof')
+    end
+
+    it 'Returns the updates from the get return use case' do
+      expect(response[:updates]).to eq([{ duck: 'quack' }])
+    end
+  end
+end

--- a/spec/unit/ui/use_case/get_returns_spec.rb
+++ b/spec/unit/ui/use_case/get_returns_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::GetReturns do
+  context 'Example one' do
+    let(:get_returns_spy) { spy(execute: { returns: [{ cat: 'meow' }] }) }
+    let(:use_case) { described_class.new(get_returns: get_returns_spy) }
+    let(:response) { use_case.execute(project_id: 2) }
+
+    before { response }
+
+    it 'Calls execute on the get returns usecase' do
+      expect(get_returns_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to the get returns use case' do
+      expect(get_returns_spy).to have_received(:execute).with(project_id: 2)
+    end
+
+    it 'Returns the found returns' do
+      expect(response).to eq(returns: [{ cat: 'meow' }])
+    end
+  end
+
+  context 'Example two' do
+    let(:get_returns_spy) { spy(execute: { returns: [{ dog: 'woof' }] }) }
+    let(:use_case) { described_class.new(get_returns: get_returns_spy) }
+    let(:response) { use_case.execute(project_id: 7) }
+
+    before { response }
+
+    it 'Calls execute on the get returns usecase' do
+      expect(get_returns_spy).to have_received(:execute)
+    end
+
+    it 'Passes the project ID to the get returns use case' do
+      expect(get_returns_spy).to have_received(:execute).with(project_id: 7)
+    end
+
+    it 'Returns the found returns' do
+      expect(response).to eq(returns: [{ dog: 'woof' }])
+    end
+  end
+end

--- a/spec/unit/ui/use_case/update_project_spec.rb
+++ b/spec/unit/ui/use_case/update_project_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::UpdateProject do
+  context 'Example one' do
+    let(:update_project_spy) { spy(execute: { successful: true }) }
+    let(:use_case) { described_class.new(update_project: update_project_spy) }
+    let(:response) { use_case.execute(id: 7, data: { cat: 'meow' }) }
+
+    before { response }
+
+    it 'Calls execute on the update project usecase' do
+      expect(update_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the update project use case the project ID' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(hash_including(project_id: 7))
+      )
+    end
+
+    it 'Passes the update project use case the project data' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            project_data: { cat: 'meow' }
+          )
+        )
+      )
+    end
+
+    it 'Returns successful if successful' do
+      expect(response).to eq(successful: true)
+    end
+  end
+
+  context 'Example two' do
+    let(:update_project_spy) { spy(execute: { successful: false }) }
+    let(:use_case) { described_class.new(update_project: update_project_spy) }
+    let(:response) { use_case.execute(id: 2, data: { dog: 'woof' }) }
+
+    before { response }
+
+    it 'Calls execute on the update project usecase' do
+      expect(update_project_spy).to have_received(:execute)
+    end
+
+    it 'Passes the update project use case the project ID' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(hash_including(project_id: 2))
+      )
+    end
+
+    it 'Passes the update project use case the project data' do
+      expect(update_project_spy).to(
+        have_received(:execute).with(
+          hash_including(
+            project_data: { dog: 'woof' }
+          )
+        )
+      )
+    end
+
+    it 'Returns successful if successful' do
+      expect(response).to eq(successful: false)
+    end
+  end
+end

--- a/spec/unit/ui/use_case/update_project_spec.rb
+++ b/spec/unit/ui/use_case/update_project_spec.rb
@@ -60,7 +60,7 @@ describe UI::UseCase::UpdateProject do
       )
     end
 
-    it 'Returns successful if successful' do
+    it 'Returns unsuccessful if unsuccessful' do
       expect(response).to eq(successful: false)
     end
   end

--- a/spec/unit/ui/use_case/update_return_spec.rb
+++ b/spec/unit/ui/use_case/update_return_spec.rb
@@ -33,7 +33,7 @@ describe UI::UseCase::UpdateReturn do
     end
   end
 
-  context 'Example one' do
+  context 'Example two' do
     let(:update_return_spy) { spy }
     let(:use_case) { described_class.new(update_return: update_return_spy) }
     let(:response) do

--- a/spec/unit/ui/use_case/update_return_spec.rb
+++ b/spec/unit/ui/use_case/update_return_spec.rb
@@ -1,0 +1,67 @@
+# frozen_string_literal: true
+
+describe UI::UseCase::UpdateReturn do
+  context 'Example one' do
+    let(:update_return_spy) { spy }
+    let(:use_case) { described_class.new(update_return: update_return_spy) }
+    let(:response) do
+      use_case.execute(return_id: 1, return_data: { cat: 'meow' })
+    end
+
+    before { response }
+
+    it 'Calls execute on update return' do
+      expect(update_return_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on update return with the return ID' do
+      expect(update_return_spy).to(
+        have_received(:execute).with(hash_including(return_id: 1))
+      )
+    end
+
+    it 'Calls execute on update return with the return data' do
+      expect(update_return_spy).to(
+        have_received(:execute).with(
+          hash_including(return_data: { cat: 'meow' })
+        )
+      )
+    end
+
+    it 'returns an empty hash' do
+      expect(response).to eq({})
+    end
+  end
+
+  context 'Example one' do
+    let(:update_return_spy) { spy }
+    let(:use_case) { described_class.new(update_return: update_return_spy) }
+    let(:response) do
+      use_case.execute(return_id: 6, return_data: { dog: 'woof' })
+    end
+
+    before { response }
+
+    it 'Calls execute on update return' do
+      expect(update_return_spy).to have_received(:execute)
+    end
+
+    it 'Calls execute on update return with the return ID' do
+      expect(update_return_spy).to(
+        have_received(:execute).with(hash_including(return_id: 6))
+      )
+    end
+
+    it 'Calls execute on update return with the return data' do
+      expect(update_return_spy).to(
+        have_received(:execute).with(
+          hash_including(return_data: { dog: 'woof' })
+        )
+      )
+    end
+
+    it 'returns an empty hash' do
+      expect(response).to eq({})
+    end
+  end
+end

--- a/spec/web_routes/create_new_project_spec.rb
+++ b/spec/web_routes/create_new_project_spec.rb
@@ -21,7 +21,7 @@ describe 'Creating a new project' do
     setup_auth_headers
 
     stub_const(
-      'HomesEngland::UseCase::CreateNewProject',
+      'UI::UseCase::CreateProject',
       double(new: create_new_project_spy)
     )
 

--- a/spec/web_routes/create_return_spec.rb
+++ b/spec/web_routes/create_return_spec.rb
@@ -14,7 +14,7 @@ describe 'Creating returns' do
 
   before do
       stub_const(
-        'LocalAuthority::UseCase::CreateReturn',
+        'UI::UseCase::CreateReturn',
         double(new: create_return_spy)
       )
 

--- a/spec/web_routes/finding_project_spec.rb
+++ b/spec/web_routes/finding_project_spec.rb
@@ -13,7 +13,7 @@ describe 'Finding a project' do
 
   before do
     stub_const(
-      'HomesEngland::UseCase::FindProject',
+      'UI::UseCase::GetProject',
       double(new: find_project_spy)
     )
 

--- a/spec/web_routes/get_base_return_spec.rb
+++ b/spec/web_routes/get_base_return_spec.rb
@@ -11,7 +11,7 @@ describe 'Getting a base return' do
 
   before do
     stub_const(
-      'LocalAuthority::UseCase::GetBaseReturn',
+      'UI::UseCase::GetBaseReturn',
       double(new: get_base_return_spy)
     )
 

--- a/spec/web_routes/get_return_spec.rb
+++ b/spec/web_routes/get_return_spec.rb
@@ -12,7 +12,7 @@ describe 'Getting a return' do
 
   before do
     stub_const(
-      'LocalAuthority::UseCase::GetReturn',
+      'UI::UseCase::GetReturn',
       double(new: get_return_spy)
     )
 

--- a/spec/web_routes/get_returns_spec.rb
+++ b/spec/web_routes/get_returns_spec.rb
@@ -8,7 +8,7 @@ describe 'Getting return history' do
 
   before do
     stub_const(
-      'LocalAuthority::UseCase::GetReturns',
+      'UI::UseCase::GetReturns',
       double(new: get_returns_spy)
     )
 

--- a/spec/web_routes/update_project_spec.rb
+++ b/spec/web_routes/update_project_spec.rb
@@ -30,13 +30,8 @@ describe 'Updating a project' do
 
   before do
     stub_const(
-      'HomesEngland::UseCase::UpdateProject',
+      'UI::UseCase::UpdateProject',
       double(new: update_project_spy)
-    )
-
-    stub_const(
-      'HomesEngland::UseCase::CreateNewProject',
-      double(new: create_new_project_spy)
     )
 
     stub_const(
@@ -83,8 +78,8 @@ describe 'Updating a project' do
     it 'should update project data for id' do
       expect(update_project_spy).to(
         have_received(:execute).with(
-          project_id: project_id,
-          project_data: { cats: 'quack', dogs: 'baa' }
+          id: project_id,
+          data: { cats: 'quack', dogs: 'baa' }
         )
       )
     end

--- a/spec/web_routes/update_return_spec.rb
+++ b/spec/web_routes/update_return_spec.rb
@@ -12,7 +12,7 @@ describe 'Updating a return' do
 
   before do
     stub_const(
-      'LocalAuthority::UseCase::SoftUpdateReturn',
+      'UI::UseCase::UpdateReturn',
       double(new: update_return_spy)
     )
 


### PR DESCRIPTION
WHAT

Adds usecases between the UI and the core application for returns

WHY

First steps towards allowing us to update the frontend schema without having to change the way it is internally stored