### PR TITLE
Add conversion methods for project related interactions

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -223,9 +223,12 @@ module DeliveryMechanism
     post '/project/update' do
       guard_access env, params, request do |request_hash|
         if valid_update_request_body(request_hash)
+          get_project_use_case = @dependency_factory.get_use_case(:ui_get_project)
+          project = get_project_use_case.execute(id: request_hash[:project_id].to_i )
           use_case = @dependency_factory.get_use_case(:ui_update_project)
           update_successful = use_case.execute(
             id: request_hash[:project_id].to_i,
+            type: project[:type],
             data: request_hash[:project_data]
           )[:successful]
           response.status = update_successful ? 200 : 404

--- a/lib/ui/use_case/convert_core_hif_project.rb
+++ b/lib/ui/use_case/convert_core_hif_project.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+class UI::UseCase::ConvertCoreHIFProject
+  def execute(project)
+    @project = project
+    @converted_project = {}
+
+    convert_project_summary
+    convert_infrastructures
+    convert_funding_profiles
+    convert_costs
+    convert_baseline_cash_flow
+    convert_recovery
+    convert_s151
+    convert_outputs_forecast
+    convert_outputs_actuals
+
+    @converted_project
+  end
+
+  private
+
+  def convert_project_summary
+    @converted_project[:summary] = {
+      BIDReference: @project[:summary][:BIDReference],
+      projectName: @project[:summary][:projectName],
+      leadAuthority: @project[:summary][:leadAuthority],
+      jointBidAreas: @project[:summary][:jointBidAreas],
+      projectDescription: @project[:summary][:projectDescription],
+      greenOrBrownField: @project[:summary][:greenOrBrownField],
+      noOfHousingSites: @project[:summary][:noOfHousingSites],
+      totalArea: @project[:summary][:totalArea],
+      hifFundingAmount: @project[:summary][:hifFundingAmount],
+      descriptionOfInfrastructure: @project[:summary][:descriptionOfInfrastructure],
+      descriptionOfWiderProjectDeliverables: @project[:summary][:descriptionOfWiderProjectDeliverables]
+    }
+  end
+
+  def convert_infrastructures
+    @converted_project[:infrastructures] = []
+    @project[:infrastructures].each do |infrastructure|
+      @converted_project[:infrastructures] << {
+        type: infrastructure[:type],
+        description: infrastructure[:description],
+        housingSitesBenefitting: infrastructure[:housingSitesBenefitting],
+        outlinePlanningStatus: {
+          granted: infrastructure[:outlinePlanningStatus][:granted],
+          reference: infrastructure[:outlinePlanningStatus][:reference],
+          targetSubmission: infrastructure[:outlinePlanningStatus][:targetSubmission],
+          targetGranted: infrastructure[:outlinePlanningStatus][:targetGranted],
+          summaryOfCriticalPath: infrastructure[:outlinePlanningStatus][:summaryOfCriticalPath]
+        },
+        fullPlanningStatus: {
+          granted: infrastructure[:fullPlanningStatus][:granted],
+          grantedReference: infrastructure[:fullPlanningStatus][:grantedReference],
+          targetSubmission: infrastructure[:fullPlanningStatus][:targetSubmission],
+          targetGranted: infrastructure[:fullPlanningStatus][:targetGranted],
+          summaryOfCriticalPath: infrastructure[:fullPlanningStatus][:summaryOfCriticalPath]
+        },
+        s106: {
+          requirement: infrastructure[:s106][:requirement],
+          summaryOfRequirement: infrastructure[:s106][:summaryOfRequirement]
+        },
+        statutoryConsents: {
+          anyConsents: infrastructure[:statutoryConsents][:anyConsents],
+          consents: infrastructure[:statutoryConsents][:consents].map do |consent|
+            {
+              detailsOfConsent: consent[:detailsOfConsent],
+              targetDateToBeMet: consent[:targetDateToBeMet]
+            }
+          end
+        },
+        landOwnership: {
+          underControlOfLA: infrastructure[:landOwnership][:underControlOfLA],
+          ownershipOfLandOtherThanLA: infrastructure[:landOwnership][:ownershipOfLandOtherThanLA],
+          landAcquisitionRequired: infrastructure[:landOwnership][:landAcquisitionRequired],
+          howManySitesToAcquire: infrastructure[:landOwnership][:howManySitesToAcquire],
+          toBeAcquiredBy: infrastructure[:landOwnership][:toBeAcquiredBy],
+          targetDateToAcquire: infrastructure[:landOwnership][:targetDateToAcquire],
+          summaryOfCriticalPath: infrastructure[:landOwnership][:summaryOfCriticalPath]
+        },
+        procurement: {
+          contractorProcured: infrastructure[:procurement][:contractorProcured],
+          nameOfContractor: infrastructure[:procurement][:nameOfContractor],
+          targetDate: infrastructure[:procurement][:targetDate],
+          summaryOfCriticalPath: infrastructure[:procurement][:summaryOfCriticalPath]
+        },
+        milestones: infrastructure[:milestones].map do |milestone|
+          {
+            descriptionOfMilestone: milestone[:descriptionOfMilestone],
+            target: milestone[:target],
+            summaryOfCriticalPath: milestone[:summaryOfCriticalPath]
+          }
+        end,
+        expectedInfrastructureStart: {
+          targetDateOfAchievingStart: infrastructure[:expectedInfrastructureStart][:targetDateOfAchievingStart]
+        },
+        expectedInfrastructureCompletion: {
+          targetDateOfAchievingCompletion: infrastructure[:expectedInfrastructureCompletion][:targetDateOfAchievingCompletion]
+        },
+        risksToAchievingTimescales: infrastructure[:risksToAchievingTimescales].map do |risk|
+          {
+            descriptionOfRisk: risk[:descriptionOfRisk],
+            impactOfRisk: risk[:impactOfRisk],
+            likelihoodOfRisk: risk[:likelihoodOfRisk],
+            mitigationOfRisk: risk[:mitigationOfRisk]
+          }
+        end
+      }
+    end
+  end
+
+  def convert_funding_profiles
+    @converted_project[:fundingProfiles] = @project[:fundingProfiles].map do |profile|
+      {
+        period: profile[:period],
+        instalment1: profile[:instalment1],
+        instalment2: profile[:instalment2],
+        instalment3: profile[:instalment3],
+        instalment4: profile[:instalment4],
+        total: profile[:total]
+      }
+    end
+  end
+
+  def convert_costs
+    @converted_project[:costs] = @project[:costs].map do |cost|
+      {
+        infrastructure: {
+          HIFAmount: cost[:infrastructure][:HIFAmount],
+          totalCostOfInfrastructure: cost[:infrastructure][:totalCostOfInfrastructure],
+          totallyFundedThroughHIF: cost[:infrastructure][:totallyFundedThroughHIF],
+          descriptionOfFundingStack: cost[:infrastructure][:descriptionOfFundingStack],
+          totalPublic: cost[:infrastructure][:totalPublic],
+          totalPrivate: cost[:infrastructure][:totalPrivate]
+        }
+      }
+    end
+  end
+
+  def convert_baseline_cash_flow
+    @converted_project[:baselineCashFlow] = {
+      summaryOfRequirement: @project[:baselineCashFlow][:summaryOfRequirement]
+    }
+  end
+
+  def convert_recovery
+    @converted_project[:recovery] = {
+      aimToRecover: @project[:recovery][:aimToRecover],
+      expectedAmountToRecover: @project[:recovery][:expectedAmountToRecover],
+      methodOfRecovery: @project[:recovery][:methodOfRecovery]
+    }
+  end
+
+  def convert_s151
+    @converted_project[:s151] = {
+      s151FundingEndDate: @project[:s151][:s151FundingEndDate],
+      s151ProjectLongstopDate: @project[:s151][:s151ProjectLongstopDate]
+    }
+  end
+
+  def convert_outputs_forecast
+    @converted_project[:outputsForecast] = {
+      totalUnits: @project[:outputsForecast][:totalUnits],
+      disposalStrategy: @project[:outputsForecast][:disposalStrategy],
+      housingForecast: @project[:outputsForecast][:housingForecast].map do |forecast|
+        {
+          period: forecast[:period],
+          target: forecast[:target],
+          housingCompletions: forecast[:housingCompletions]
+        }
+      end
+    }
+  end
+
+  def convert_outputs_actuals
+    @converted_project[:outputsActuals] = {
+      siteOutputs: @project[:outputsActuals][:siteOutputs].map do |output|
+        {
+          siteName: output[:siteName],
+          siteLocalAuthority: output[:siteLocalAuthority],
+          siteNumberOfUnits: output[:siteNumberOfUnits]
+        }
+      end
+    }
+  end
+end

--- a/lib/ui/use_case/convert_core_hif_project.rb
+++ b/lib/ui/use_case/convert_core_hif_project.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class UI::UseCase::ConvertCoreHIFProject
-  def execute(project)
-    @project = project
+  def execute(project_data:)
+    @project = project_data
     @converted_project = {}
 
     convert_project_summary

--- a/lib/ui/use_case/convert_core_hif_project.rb
+++ b/lib/ui/use_case/convert_core_hif_project.rb
@@ -21,6 +21,8 @@ class UI::UseCase::ConvertCoreHIFProject
   private
 
   def convert_project_summary
+    return if @project[:summary].nil?
+
     @converted_project[:summary] = {
       BIDReference: @project[:summary][:BIDReference],
       projectName: @project[:summary][:projectName],
@@ -34,34 +36,46 @@ class UI::UseCase::ConvertCoreHIFProject
       descriptionOfInfrastructure: @project[:summary][:descriptionOfInfrastructure],
       descriptionOfWiderProjectDeliverables: @project[:summary][:descriptionOfWiderProjectDeliverables]
     }
+
+    @converted_project[:summary].compact!
   end
 
   def convert_infrastructures
-    @converted_project[:infrastructures] = []
-    @project[:infrastructures].each do |infrastructure|
-      @converted_project[:infrastructures] << {
-        type: infrastructure[:type],
-        description: infrastructure[:description],
-        housingSitesBenefitting: infrastructure[:housingSitesBenefitting],
-        outlinePlanningStatus: {
+    @converted_project[:infrastructures] = @project[:infrastructures].map do |infrastructure|
+      converted_infrastructure = {}
+      converted_infrastructure[:type] = infrastructure[:type]
+      converted_infrastructure[:description] = infrastructure[:description]
+      converted_infrastructure[:housingSitesBenefitting] = infrastructure[:housingSitesBenefitting]
+
+      unless infrastructure[:outlinePlanningStatus].nil?
+        converted_infrastructure[:outlinePlanningStatus] = {
           granted: infrastructure[:outlinePlanningStatus][:granted],
           reference: infrastructure[:outlinePlanningStatus][:reference],
           targetSubmission: infrastructure[:outlinePlanningStatus][:targetSubmission],
           targetGranted: infrastructure[:outlinePlanningStatus][:targetGranted],
           summaryOfCriticalPath: infrastructure[:outlinePlanningStatus][:summaryOfCriticalPath]
-        },
-        fullPlanningStatus: {
+        }
+      end
+
+      unless infrastructure[:fullPlanningStatus].nil?
+        converted_infrastructure[:fullPlanningStatus] = {
           granted: infrastructure[:fullPlanningStatus][:granted],
           grantedReference: infrastructure[:fullPlanningStatus][:grantedReference],
           targetSubmission: infrastructure[:fullPlanningStatus][:targetSubmission],
           targetGranted: infrastructure[:fullPlanningStatus][:targetGranted],
           summaryOfCriticalPath: infrastructure[:fullPlanningStatus][:summaryOfCriticalPath]
-        },
-        s106: {
+        }
+      end
+
+      unless infrastructure[:s106].nil?
+        converted_infrastructure[:s106] = {
           requirement: infrastructure[:s106][:requirement],
           summaryOfRequirement: infrastructure[:s106][:summaryOfRequirement]
-        },
-        statutoryConsents: {
+        }
+      end
+
+      unless infrastructure[:statutoryConsents].nil?
+        converted_infrastructure[:statutoryConsents] = {
           anyConsents: infrastructure[:statutoryConsents][:anyConsents],
           consents: infrastructure[:statutoryConsents][:consents].map do |consent|
             {
@@ -69,8 +83,11 @@ class UI::UseCase::ConvertCoreHIFProject
               targetDateToBeMet: consent[:targetDateToBeMet]
             }
           end
-        },
-        landOwnership: {
+        }
+      end
+
+      unless infrastructure[:landOwnership].nil?
+        converted_infrastructure[:landOwnership] = {
           underControlOfLA: infrastructure[:landOwnership][:underControlOfLA],
           ownershipOfLandOtherThanLA: infrastructure[:landOwnership][:ownershipOfLandOtherThanLA],
           landAcquisitionRequired: infrastructure[:landOwnership][:landAcquisitionRequired],
@@ -78,27 +95,42 @@ class UI::UseCase::ConvertCoreHIFProject
           toBeAcquiredBy: infrastructure[:landOwnership][:toBeAcquiredBy],
           targetDateToAcquire: infrastructure[:landOwnership][:targetDateToAcquire],
           summaryOfCriticalPath: infrastructure[:landOwnership][:summaryOfCriticalPath]
-        },
-        procurement: {
+        }
+      end
+
+      unless infrastructure[:procurement].nil?
+        converted_infrastructure[:procurement] = {
           contractorProcured: infrastructure[:procurement][:contractorProcured],
           nameOfContractor: infrastructure[:procurement][:nameOfContractor],
           targetDate: infrastructure[:procurement][:targetDate],
           summaryOfCriticalPath: infrastructure[:procurement][:summaryOfCriticalPath]
-        },
-        milestones: infrastructure[:milestones].map do |milestone|
+        }
+      end
+
+      unless infrastructure[:milestones].nil?
+        converted_infrastructure[:milestones] = infrastructure[:milestones].map do |milestone|
           {
             descriptionOfMilestone: milestone[:descriptionOfMilestone],
             target: milestone[:target],
             summaryOfCriticalPath: milestone[:summaryOfCriticalPath]
           }
-        end,
-        expectedInfrastructureStart: {
+        end
+      end
+
+      unless infrastructure[:expectedInfrastructureStart].nil?
+        converted_infrastructure[:expectedInfrastructureStart] = {
           targetDateOfAchievingStart: infrastructure[:expectedInfrastructureStart][:targetDateOfAchievingStart]
-        },
-        expectedInfrastructureCompletion: {
+        }
+      end
+
+      unless infrastructure[:expectedInfrastructureCompletion].nil?
+        converted_infrastructure[:expectedInfrastructureCompletion] = {
           targetDateOfAchievingCompletion: infrastructure[:expectedInfrastructureCompletion][:targetDateOfAchievingCompletion]
-        },
-        risksToAchievingTimescales: infrastructure[:risksToAchievingTimescales].map do |risk|
+        }
+      end
+
+      unless infrastructure[:risksToAchievingTimescales].nil?
+        converted_infrastructure[:risksToAchievingTimescales] = infrastructure[:risksToAchievingTimescales].map do |risk|
           {
             descriptionOfRisk: risk[:descriptionOfRisk],
             impactOfRisk: risk[:impactOfRisk],
@@ -106,7 +138,9 @@ class UI::UseCase::ConvertCoreHIFProject
             mitigationOfRisk: risk[:mitigationOfRisk]
           }
         end
-      }
+      end
+
+      converted_infrastructure.compact
     end
   end
 
@@ -121,12 +155,19 @@ class UI::UseCase::ConvertCoreHIFProject
         total: profile[:total]
       }
     end
+
+    @converted_project[:fundingProfiles].each(&:compact!)
   end
 
   def convert_costs
-    @converted_project[:costs] = @project[:costs].map do |cost|
-      {
-        infrastructure: {
+    return if @project[:costs].nil?
+    @converted_project[:costs] = []
+
+    @converted_project[:costs] = @project[:costs].each do |cost|
+      converted_cost = {}
+
+      unless cost[:infrastructures].nil?
+        converted_cost[:infrastructure] = {
           HIFAmount: cost[:infrastructure][:HIFAmount],
           totalCostOfInfrastructure: cost[:infrastructure][:totalCostOfInfrastructure],
           totallyFundedThroughHIF: cost[:infrastructure][:totallyFundedThroughHIF],
@@ -134,25 +175,35 @@ class UI::UseCase::ConvertCoreHIFProject
           totalPublic: cost[:infrastructure][:totalPublic],
           totalPrivate: cost[:infrastructure][:totalPrivate]
         }
-      }
+      end
+
+      @converted_project[:costs] << converted_cost
     end
   end
 
   def convert_baseline_cash_flow
+    return if @project[:baselineCashFlow].nil?
+
     @converted_project[:baselineCashFlow] = {
       summaryOfRequirement: @project[:baselineCashFlow][:summaryOfRequirement]
     }
   end
 
   def convert_recovery
+    return if @project[:recovery].nil?
+
     @converted_project[:recovery] = {
       aimToRecover: @project[:recovery][:aimToRecover],
       expectedAmountToRecover: @project[:recovery][:expectedAmountToRecover],
       methodOfRecovery: @project[:recovery][:methodOfRecovery]
     }
+
+    @converted_project[:recovery].compact!
   end
 
   def convert_s151
+    return if @project[:s151].nil?
+
     @converted_project[:s151] = {
       s151FundingEndDate: @project[:s151][:s151FundingEndDate],
       s151ProjectLongstopDate: @project[:s151][:s151ProjectLongstopDate]
@@ -160,20 +211,33 @@ class UI::UseCase::ConvertCoreHIFProject
   end
 
   def convert_outputs_forecast
+    return if @project[:outputsForecast].nil?
+
     @converted_project[:outputsForecast] = {
       totalUnits: @project[:outputsForecast][:totalUnits],
-      disposalStrategy: @project[:outputsForecast][:disposalStrategy],
-      housingForecast: @project[:outputsForecast][:housingForecast].map do |forecast|
-        {
-          period: forecast[:period],
-          target: forecast[:target],
-          housingCompletions: forecast[:housingCompletions]
-        }
-      end
+      disposalStrategy: @project[:outputsForecast][:disposalStrategy]
     }
+
+    @converted_project[:outputsForecast].compact!
+
+    return if @project[:outputsForecast][:housingForecast].nil?
+
+    @converted_project[:outputsForecast][:housingForecast] = @project[:outputsForecast][:housingForecast].map do |forecast|
+      {
+        period: forecast[:period],
+        target: forecast[:target],
+        housingCompletions: forecast[:housingCompletions]
+      }
+    end
   end
 
   def convert_outputs_actuals
+    return if @project[:outputsActuals].nil?
+
+    @converted_project[:outputsActuals] = {}
+
+    return if @project[:outputsActuals][:siteOutputs].nil?
+
     @converted_project[:outputsActuals] = {
       siteOutputs: @project[:outputsActuals][:siteOutputs].map do |output|
         {

--- a/lib/ui/use_case/convert_ui_hif_project.rb
+++ b/lib/ui/use_case/convert_ui_hif_project.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 class UI::UseCase::ConvertUIHIFProject
-  def execute(project)
-    @project = project
+  def execute(project_data:)
+    @project = project_data
     @converted_project = {}
 
     convert_project_summary

--- a/lib/ui/use_case/convert_ui_hif_project.rb
+++ b/lib/ui/use_case/convert_ui_hif_project.rb
@@ -21,6 +21,8 @@ class UI::UseCase::ConvertUIHIFProject
   private
 
   def convert_project_summary
+    return if @project[:summary].nil?
+
     @converted_project[:summary] = {
       BIDReference: @project[:summary][:BIDReference],
       projectName: @project[:summary][:projectName],
@@ -34,34 +36,46 @@ class UI::UseCase::ConvertUIHIFProject
       descriptionOfInfrastructure: @project[:summary][:descriptionOfInfrastructure],
       descriptionOfWiderProjectDeliverables: @project[:summary][:descriptionOfWiderProjectDeliverables]
     }
+
+    @converted_project[:summary].compact!
   end
 
   def convert_infrastructures
-    @converted_project[:infrastructures] = []
-    @project[:infrastructures].each do |infrastructure|
-      @converted_project[:infrastructures] << {
-        type: infrastructure[:type],
-        description: infrastructure[:description],
-        housingSitesBenefitting: infrastructure[:housingSitesBenefitting],
-        outlinePlanningStatus: {
+    @converted_project[:infrastructures] = @project[:infrastructures].map do |infrastructure|
+      converted_infrastructure = {}
+      converted_infrastructure[:type] = infrastructure[:type]
+      converted_infrastructure[:description] = infrastructure[:description]
+      converted_infrastructure[:housingSitesBenefitting] = infrastructure[:housingSitesBenefitting]
+
+      unless infrastructure[:outlinePlanningStatus].nil?
+        converted_infrastructure[:outlinePlanningStatus] = {
           granted: infrastructure[:outlinePlanningStatus][:granted],
           reference: infrastructure[:outlinePlanningStatus][:reference],
           targetSubmission: infrastructure[:outlinePlanningStatus][:targetSubmission],
           targetGranted: infrastructure[:outlinePlanningStatus][:targetGranted],
           summaryOfCriticalPath: infrastructure[:outlinePlanningStatus][:summaryOfCriticalPath]
-        },
-        fullPlanningStatus: {
+        }
+      end
+
+      unless infrastructure[:fullPlanningStatus].nil?
+        converted_infrastructure[:fullPlanningStatus] = {
           granted: infrastructure[:fullPlanningStatus][:granted],
           grantedReference: infrastructure[:fullPlanningStatus][:grantedReference],
           targetSubmission: infrastructure[:fullPlanningStatus][:targetSubmission],
           targetGranted: infrastructure[:fullPlanningStatus][:targetGranted],
           summaryOfCriticalPath: infrastructure[:fullPlanningStatus][:summaryOfCriticalPath]
-        },
-        s106: {
+        }
+      end
+
+      unless infrastructure[:s106].nil?
+        converted_infrastructure[:s106] = {
           requirement: infrastructure[:s106][:requirement],
           summaryOfRequirement: infrastructure[:s106][:summaryOfRequirement]
-        },
-        statutoryConsents: {
+        }
+      end
+
+      unless infrastructure[:statutoryConsents].nil?
+        converted_infrastructure[:statutoryConsents] = {
           anyConsents: infrastructure[:statutoryConsents][:anyConsents],
           consents: infrastructure[:statutoryConsents][:consents].map do |consent|
             {
@@ -69,8 +83,11 @@ class UI::UseCase::ConvertUIHIFProject
               targetDateToBeMet: consent[:targetDateToBeMet]
             }
           end
-        },
-        landOwnership: {
+        }
+      end
+
+      unless infrastructure[:landOwnership].nil?
+        converted_infrastructure[:landOwnership] = {
           underControlOfLA: infrastructure[:landOwnership][:underControlOfLA],
           ownershipOfLandOtherThanLA: infrastructure[:landOwnership][:ownershipOfLandOtherThanLA],
           landAcquisitionRequired: infrastructure[:landOwnership][:landAcquisitionRequired],
@@ -78,27 +95,42 @@ class UI::UseCase::ConvertUIHIFProject
           toBeAcquiredBy: infrastructure[:landOwnership][:toBeAcquiredBy],
           targetDateToAcquire: infrastructure[:landOwnership][:targetDateToAcquire],
           summaryOfCriticalPath: infrastructure[:landOwnership][:summaryOfCriticalPath]
-        },
-        procurement: {
+        }
+      end
+
+      unless infrastructure[:procurement].nil?
+        converted_infrastructure[:procurement] = {
           contractorProcured: infrastructure[:procurement][:contractorProcured],
           nameOfContractor: infrastructure[:procurement][:nameOfContractor],
           targetDate: infrastructure[:procurement][:targetDate],
           summaryOfCriticalPath: infrastructure[:procurement][:summaryOfCriticalPath]
-        },
-        milestones: infrastructure[:milestones].map do |milestone|
+        }
+      end
+
+      unless infrastructure[:milestones].nil?
+        converted_infrastructure[:milestones] = infrastructure[:milestones].map do |milestone|
           {
             descriptionOfMilestone: milestone[:descriptionOfMilestone],
             target: milestone[:target],
             summaryOfCriticalPath: milestone[:summaryOfCriticalPath]
           }
-        end,
-        expectedInfrastructureStart: {
+        end
+      end
+
+      unless infrastructure[:expectedInfrastructureStart].nil?
+        converted_infrastructure[:expectedInfrastructureStart] = {
           targetDateOfAchievingStart: infrastructure[:expectedInfrastructureStart][:targetDateOfAchievingStart]
-        },
-        expectedInfrastructureCompletion: {
+        }
+      end
+
+      unless infrastructure[:expectedInfrastructureCompletion].nil?
+        converted_infrastructure[:expectedInfrastructureCompletion] = {
           targetDateOfAchievingCompletion: infrastructure[:expectedInfrastructureCompletion][:targetDateOfAchievingCompletion]
-        },
-        risksToAchievingTimescales: infrastructure[:risksToAchievingTimescales].map do |risk|
+        }
+      end
+
+      unless infrastructure[:risksToAchievingTimescales].nil?
+        converted_infrastructure[:risksToAchievingTimescales] = infrastructure[:risksToAchievingTimescales].map do |risk|
           {
             descriptionOfRisk: risk[:descriptionOfRisk],
             impactOfRisk: risk[:impactOfRisk],
@@ -106,7 +138,9 @@ class UI::UseCase::ConvertUIHIFProject
             mitigationOfRisk: risk[:mitigationOfRisk]
           }
         end
-      }
+      end
+
+      converted_infrastructure.compact
     end
   end
 
@@ -121,12 +155,19 @@ class UI::UseCase::ConvertUIHIFProject
         total: profile[:total]
       }
     end
+
+    @converted_project[:fundingProfiles].each(&:compact!)
   end
 
   def convert_costs
-    @converted_project[:costs] = @project[:costs].map do |cost|
-      {
-        infrastructure: {
+    return if @project[:costs].nil?
+    @converted_project[:costs] = []
+
+    @converted_project[:costs] = @project[:costs].each do |cost|
+      converted_cost = {}
+
+      unless cost[:infrastructures].nil?
+        converted_cost[:infrastructure] = {
           HIFAmount: cost[:infrastructure][:HIFAmount],
           totalCostOfInfrastructure: cost[:infrastructure][:totalCostOfInfrastructure],
           totallyFundedThroughHIF: cost[:infrastructure][:totallyFundedThroughHIF],
@@ -134,25 +175,35 @@ class UI::UseCase::ConvertUIHIFProject
           totalPublic: cost[:infrastructure][:totalPublic],
           totalPrivate: cost[:infrastructure][:totalPrivate]
         }
-      }
+      end
+
+      @converted_project[:costs] << converted_cost
     end
   end
 
   def convert_baseline_cash_flow
+    return if @project[:baselineCashFlow].nil?
+
     @converted_project[:baselineCashFlow] = {
       summaryOfRequirement: @project[:baselineCashFlow][:summaryOfRequirement]
     }
   end
 
   def convert_recovery
+    return if @project[:recovery].nil?
+
     @converted_project[:recovery] = {
       aimToRecover: @project[:recovery][:aimToRecover],
       expectedAmountToRecover: @project[:recovery][:expectedAmountToRecover],
       methodOfRecovery: @project[:recovery][:methodOfRecovery]
     }
+
+    @converted_project[:recovery].compact!
   end
 
   def convert_s151
+    return if @project[:s151].nil?
+
     @converted_project[:s151] = {
       s151FundingEndDate: @project[:s151][:s151FundingEndDate],
       s151ProjectLongstopDate: @project[:s151][:s151ProjectLongstopDate]
@@ -160,20 +211,33 @@ class UI::UseCase::ConvertUIHIFProject
   end
 
   def convert_outputs_forecast
+    return if @project[:outputsForecast].nil?
+
     @converted_project[:outputsForecast] = {
       totalUnits: @project[:outputsForecast][:totalUnits],
-      disposalStrategy: @project[:outputsForecast][:disposalStrategy],
-      housingForecast: @project[:outputsForecast][:housingForecast].map do |forecast|
-        {
-          period: forecast[:period],
-          target: forecast[:target],
-          housingCompletions: forecast[:housingCompletions]
-        }
-      end
+      disposalStrategy: @project[:outputsForecast][:disposalStrategy]
     }
+
+    @converted_project[:outputsForecast].compact!
+
+    return if @project[:outputsForecast][:housingForecast].nil?
+
+    @converted_project[:outputsForecast][:housingForecast] = @project[:outputsForecast][:housingForecast].map do |forecast|
+      {
+        period: forecast[:period],
+        target: forecast[:target],
+        housingCompletions: forecast[:housingCompletions]
+      }
+    end
   end
 
   def convert_outputs_actuals
+    return if @project[:outputsActuals].nil?
+
+    @converted_project[:outputsActuals] = {}
+
+    return if @project[:outputsActuals][:siteOutputs].nil?
+
     @converted_project[:outputsActuals] = {
       siteOutputs: @project[:outputsActuals][:siteOutputs].map do |output|
         {

--- a/lib/ui/use_case/convert_ui_hif_project.rb
+++ b/lib/ui/use_case/convert_ui_hif_project.rb
@@ -1,0 +1,187 @@
+# frozen_string_literal: true
+
+class UI::UseCase::ConvertUIHIFProject
+  def execute(project)
+    @project = project
+    @converted_project = {}
+
+    convert_project_summary
+    convert_infrastructures
+    convert_funding_profiles
+    convert_costs
+    convert_baseline_cash_flow
+    convert_recovery
+    convert_s151
+    convert_outputs_forecast
+    convert_outputs_actuals
+
+    @converted_project
+  end
+
+  private
+
+  def convert_project_summary
+    @converted_project[:summary] = {
+      BIDReference: @project[:summary][:BIDReference],
+      projectName: @project[:summary][:projectName],
+      leadAuthority: @project[:summary][:leadAuthority],
+      jointBidAreas: @project[:summary][:jointBidAreas],
+      projectDescription: @project[:summary][:projectDescription],
+      greenOrBrownField: @project[:summary][:greenOrBrownField],
+      noOfHousingSites: @project[:summary][:noOfHousingSites],
+      totalArea: @project[:summary][:totalArea],
+      hifFundingAmount: @project[:summary][:hifFundingAmount],
+      descriptionOfInfrastructure: @project[:summary][:descriptionOfInfrastructure],
+      descriptionOfWiderProjectDeliverables: @project[:summary][:descriptionOfWiderProjectDeliverables]
+    }
+  end
+
+  def convert_infrastructures
+    @converted_project[:infrastructures] = []
+    @project[:infrastructures].each do |infrastructure|
+      @converted_project[:infrastructures] << {
+        type: infrastructure[:type],
+        description: infrastructure[:description],
+        housingSitesBenefitting: infrastructure[:housingSitesBenefitting],
+        outlinePlanningStatus: {
+          granted: infrastructure[:outlinePlanningStatus][:granted],
+          reference: infrastructure[:outlinePlanningStatus][:reference],
+          targetSubmission: infrastructure[:outlinePlanningStatus][:targetSubmission],
+          targetGranted: infrastructure[:outlinePlanningStatus][:targetGranted],
+          summaryOfCriticalPath: infrastructure[:outlinePlanningStatus][:summaryOfCriticalPath]
+        },
+        fullPlanningStatus: {
+          granted: infrastructure[:fullPlanningStatus][:granted],
+          grantedReference: infrastructure[:fullPlanningStatus][:grantedReference],
+          targetSubmission: infrastructure[:fullPlanningStatus][:targetSubmission],
+          targetGranted: infrastructure[:fullPlanningStatus][:targetGranted],
+          summaryOfCriticalPath: infrastructure[:fullPlanningStatus][:summaryOfCriticalPath]
+        },
+        s106: {
+          requirement: infrastructure[:s106][:requirement],
+          summaryOfRequirement: infrastructure[:s106][:summaryOfRequirement]
+        },
+        statutoryConsents: {
+          anyConsents: infrastructure[:statutoryConsents][:anyConsents],
+          consents: infrastructure[:statutoryConsents][:consents].map do |consent|
+            {
+              detailsOfConsent: consent[:detailsOfConsent],
+              targetDateToBeMet: consent[:targetDateToBeMet]
+            }
+          end
+        },
+        landOwnership: {
+          underControlOfLA: infrastructure[:landOwnership][:underControlOfLA],
+          ownershipOfLandOtherThanLA: infrastructure[:landOwnership][:ownershipOfLandOtherThanLA],
+          landAcquisitionRequired: infrastructure[:landOwnership][:landAcquisitionRequired],
+          howManySitesToAcquire: infrastructure[:landOwnership][:howManySitesToAcquire],
+          toBeAcquiredBy: infrastructure[:landOwnership][:toBeAcquiredBy],
+          targetDateToAcquire: infrastructure[:landOwnership][:targetDateToAcquire],
+          summaryOfCriticalPath: infrastructure[:landOwnership][:summaryOfCriticalPath]
+        },
+        procurement: {
+          contractorProcured: infrastructure[:procurement][:contractorProcured],
+          nameOfContractor: infrastructure[:procurement][:nameOfContractor],
+          targetDate: infrastructure[:procurement][:targetDate],
+          summaryOfCriticalPath: infrastructure[:procurement][:summaryOfCriticalPath]
+        },
+        milestones: infrastructure[:milestones].map do |milestone|
+          {
+            descriptionOfMilestone: milestone[:descriptionOfMilestone],
+            target: milestone[:target],
+            summaryOfCriticalPath: milestone[:summaryOfCriticalPath]
+          }
+        end,
+        expectedInfrastructureStart: {
+          targetDateOfAchievingStart: infrastructure[:expectedInfrastructureStart][:targetDateOfAchievingStart]
+        },
+        expectedInfrastructureCompletion: {
+          targetDateOfAchievingCompletion: infrastructure[:expectedInfrastructureCompletion][:targetDateOfAchievingCompletion]
+        },
+        risksToAchievingTimescales: infrastructure[:risksToAchievingTimescales].map do |risk|
+          {
+            descriptionOfRisk: risk[:descriptionOfRisk],
+            impactOfRisk: risk[:impactOfRisk],
+            likelihoodOfRisk: risk[:likelihoodOfRisk],
+            mitigationOfRisk: risk[:mitigationOfRisk]
+          }
+        end
+      }
+    end
+  end
+
+  def convert_funding_profiles
+    @converted_project[:fundingProfiles] = @project[:fundingProfiles].map do |profile|
+      {
+        period: profile[:period],
+        instalment1: profile[:instalment1],
+        instalment2: profile[:instalment2],
+        instalment3: profile[:instalment3],
+        instalment4: profile[:instalment4],
+        total: profile[:total]
+      }
+    end
+  end
+
+  def convert_costs
+    @converted_project[:costs] = @project[:costs].map do |cost|
+      {
+        infrastructure: {
+          HIFAmount: cost[:infrastructure][:HIFAmount],
+          totalCostOfInfrastructure: cost[:infrastructure][:totalCostOfInfrastructure],
+          totallyFundedThroughHIF: cost[:infrastructure][:totallyFundedThroughHIF],
+          descriptionOfFundingStack: cost[:infrastructure][:descriptionOfFundingStack],
+          totalPublic: cost[:infrastructure][:totalPublic],
+          totalPrivate: cost[:infrastructure][:totalPrivate]
+        }
+      }
+    end
+  end
+
+  def convert_baseline_cash_flow
+    @converted_project[:baselineCashFlow] = {
+      summaryOfRequirement: @project[:baselineCashFlow][:summaryOfRequirement]
+    }
+  end
+
+  def convert_recovery
+    @converted_project[:recovery] = {
+      aimToRecover: @project[:recovery][:aimToRecover],
+      expectedAmountToRecover: @project[:recovery][:expectedAmountToRecover],
+      methodOfRecovery: @project[:recovery][:methodOfRecovery]
+    }
+  end
+
+  def convert_s151
+    @converted_project[:s151] = {
+      s151FundingEndDate: @project[:s151][:s151FundingEndDate],
+      s151ProjectLongstopDate: @project[:s151][:s151ProjectLongstopDate]
+    }
+  end
+
+  def convert_outputs_forecast
+    @converted_project[:outputsForecast] = {
+      totalUnits: @project[:outputsForecast][:totalUnits],
+      disposalStrategy: @project[:outputsForecast][:disposalStrategy],
+      housingForecast: @project[:outputsForecast][:housingForecast].map do |forecast|
+        {
+          period: forecast[:period],
+          target: forecast[:target],
+          housingCompletions: forecast[:housingCompletions]
+        }
+      end
+    }
+  end
+
+  def convert_outputs_actuals
+    @converted_project[:outputsActuals] = {
+      siteOutputs: @project[:outputsActuals][:siteOutputs].map do |output|
+        {
+          siteName: output[:siteName],
+          siteLocalAuthority: output[:siteLocalAuthority],
+          siteNumberOfUnits: output[:siteNumberOfUnits]
+        }
+      end
+    }
+  end
+end

--- a/lib/ui/use_case/create_project.rb
+++ b/lib/ui/use_case/create_project.rb
@@ -1,16 +1,25 @@
+# frozen_string_literal: true
+
 class UI::UseCase::CreateProject
-  def initialize(create_project:)
+  def initialize(create_project:, convert_ui_hif_project:)
     @create_project = create_project
+    @convert_ui_hif_project = convert_ui_hif_project
   end
 
   def execute(type:, name:, baseline:)
+    baseline = convert_baseline(baseline) if type == 'hif'
     created_id = @create_project.execute(
-      type: type, 
-      name: name, 
+      type: type,
+      name: name,
       baseline: baseline
     )[:id]
 
     { id: created_id }
   end
-end
 
+  private
+
+  def convert_baseline(baseline)
+    @convert_ui_hif_project.execute(project_data: baseline)
+  end
+end

--- a/lib/ui/use_case/get_project.rb
+++ b/lib/ui/use_case/get_project.rb
@@ -1,12 +1,15 @@
 # frozen_string_literal: true
 
 class UI::UseCase::GetProject
-  def initialize(find_project:)
+  def initialize(find_project:, convert_core_hif_project:)
     @find_project = find_project
+    @convert_core_hif_project = convert_core_hif_project
   end
 
   def execute(id:)
     found_project = @find_project.execute(id: id)
+
+    found_project[:data] = convert_data(found_project) unless found_project[:type] != 'hif'
 
     {
       name: found_project[:name],
@@ -14,5 +17,11 @@ class UI::UseCase::GetProject
       data: found_project[:data],
       status: found_project[:status]
     }
+  end
+
+  private
+
+  def convert_data(project)
+    @convert_core_hif_project.execute(project_data: project[:data])
   end
 end

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -1,16 +1,24 @@
 # frozen_string_literal: true
 
 class UI::UseCase::UpdateProject
-  def initialize(update_project:)
+  def initialize(update_project:, convert_ui_hif_project:)
     @update_project = update_project
+    @convert_ui_hif_project = convert_ui_hif_project
   end
 
-  def execute(id:, data:)
+  def execute(id:, data:, type: nil)
+    data = convert_data(data) if type == 'hif'
     successful = @update_project.execute(
       project_id: id,
       project_data: data
     )[:successful]
 
     { successful: successful }
+  end
+
+  private 
+
+  def convert_data(data)
+    @convert_ui_hif_project.execute(project_data: data)
   end
 end

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -2,21 +2,32 @@
 
 class UI::UseCases
   def self.register(builder)
+    builder.define_use_case :convert_core_hif_project do
+      UI::UseCase::ConvertCoreHIFProject.new
+    end
+
+    builder.define_use_case :convert_ui_hif_project do
+      UI::UseCase::ConvertUIHIFProject.new
+    end
+
     builder.define_use_case :ui_create_project do
       UI::UseCase::CreateProject.new(
-        create_project: builder.get_use_case(:create_new_project)
+        create_project: builder.get_use_case(:create_new_project),
+        convert_ui_hif_project: builder.get_use_case(:convert_ui_hif_project)
       )
     end
 
     builder.define_use_case :ui_get_project do
       UI::UseCase::GetProject.new(
-        find_project: builder.get_use_case(:find_project)
+        find_project: builder.get_use_case(:find_project),
+        convert_core_hif_project: builder.get_use_case(:convert_core_hif_project)
       )
     end
 
     builder.define_use_case :ui_update_project do
       UI::UseCase::UpdateProject.new(
-        update_project: builder.get_use_case(:update_project)
+        update_project: builder.get_use_case(:update_project),
+        convert_ui_hif_project: builder.get_use_case(:convert_ui_hif_project)
       )
     end
 

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -12,6 +12,13 @@ describe 'Interacting with a HIF Project from the UI' do
     )
   end
 
+  let(:empty_baseline_data) do
+    JSON.parse(
+      File.open("#{__dir__}/../../fixtures/hif_empty_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
   let(:updated_baseline_data) do
     JSON.parse(
       File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
@@ -24,6 +31,14 @@ describe 'Interacting with a HIF Project from the UI' do
       type: 'hif',
       name: 'Cat Infrastructures',
       baseline: baseline_data
+    )[:id]
+  end
+
+  def create_empty_project
+    dependency_factory.get_use_case(:ui_create_project).execute(
+      type: 'hif',
+      name: 'Cat Infrastructures',
+      baseline: empty_baseline_data
     )[:id]
   end
 
@@ -41,6 +56,15 @@ describe 'Interacting with a HIF Project from the UI' do
       expect(created_project[:type]).to eq('hif')
       expect(created_project[:name]).to eq('Cat Infrastructures')
       expect(created_project[:data]).to eq(baseline_data)
+    end
+
+    it 'Can create an empty project successfully' do
+      project_id = create_empty_project
+      created_project = get_project(project_id)
+
+      expect(created_project[:type]).to eq('hif')
+      expect(created_project[:name]).to eq('Cat Infrastructures')
+      expect(created_project[:data]).to eq(empty_baseline_data)
     end
   end
 

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -5,11 +5,25 @@ require_relative '../shared_context/dependency_factory'
 describe 'Interacting with a HIF Project from the UI' do
   include_context 'dependency factory'
 
+  let(:baseline_data) do
+    JSON.parse(
+      File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
+  let(:updated_baseline_data) do
+    JSON.parse(
+      File.open("#{__dir__}/../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
   def create_project
     dependency_factory.get_use_case(:ui_create_project).execute(
       type: 'hif',
       name: 'Cat Infrastructures',
-      baseline: { cat: 'meow' }
+      baseline: baseline_data
     )[:id]
   end
 
@@ -26,7 +40,7 @@ describe 'Interacting with a HIF Project from the UI' do
 
       expect(created_project[:type]).to eq('hif')
       expect(created_project[:name]).to eq('Cat Infrastructures')
-      expect(created_project[:data]).to eq(cat: 'meow')
+      expect(created_project[:data]).to eq(baseline_data)
     end
   end
 
@@ -34,11 +48,11 @@ describe 'Interacting with a HIF Project from the UI' do
     it 'Can update a created project successfully' do
       project_id = create_project
 
-      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: { cat: 'mew' })
+      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: updated_baseline_data)
 
       updated_project = get_project(project_id)
 
-      expect(updated_project[:data]).to eq(cat: 'mew')
+      expect(updated_project[:data]).to eq(updated_baseline_data)
     end
   end
 end

--- a/spec/fixtures/hif_empty_baseline.json
+++ b/spec/fixtures/hif_empty_baseline.json
@@ -1,0 +1,10 @@
+{
+  "summary": {},
+  "infrastructures": [{}],
+  "fundingProfiles": [{}, {}, {}],
+  "costs": [{}],
+  "baselineCashFlow": { "summaryOfRequirement": "" },
+  "recovery": {},
+  "outputsForecast": {},
+  "outputsActuals": {}
+}

--- a/spec/unit/ui/use_case/convert_core_hif_project_spec.rb
+++ b/spec/unit/ui/use_case/convert_core_hif_project_spec.rb
@@ -1,0 +1,14 @@
+describe UI::UseCase::ConvertCoreHIFProject do
+  let(:project_to_convert) do
+    JSON.parse(
+      File.open("#{__dir__}/../../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
+  it 'Converts the project correctly' do
+    converted_project = described_class.new.execute(project_to_convert)
+
+    expect(converted_project).to eq(project_to_convert)
+  end
+end

--- a/spec/unit/ui/use_case/convert_core_hif_project_spec.rb
+++ b/spec/unit/ui/use_case/convert_core_hif_project_spec.rb
@@ -7,7 +7,7 @@ describe UI::UseCase::ConvertCoreHIFProject do
   end
 
   it 'Converts the project correctly' do
-    converted_project = described_class.new.execute(project_to_convert)
+    converted_project = described_class.new.execute(project_data: project_to_convert)
 
     expect(converted_project).to eq(project_to_convert)
   end

--- a/spec/unit/ui/use_case/convert_ui_hif_project_spec.rb
+++ b/spec/unit/ui/use_case/convert_ui_hif_project_spec.rb
@@ -1,0 +1,14 @@
+describe UI::UseCase::ConvertUIHIFProject do
+  let(:project_to_convert) do
+    JSON.parse(
+      File.open("#{__dir__}/../../../fixtures/hif_baseline.json").read,
+      symbolize_names: true
+    )
+  end
+
+  it 'Converts the project correctly' do
+    converted_project = described_class.new.execute(project_to_convert)
+
+    expect(converted_project).to eq(project_to_convert)
+  end
+end

--- a/spec/unit/ui/use_case/convert_ui_hif_project_spec.rb
+++ b/spec/unit/ui/use_case/convert_ui_hif_project_spec.rb
@@ -7,7 +7,7 @@ describe UI::UseCase::ConvertUIHIFProject do
   end
 
   it 'Converts the project correctly' do
-    converted_project = described_class.new.execute(project_to_convert)
+    converted_project = described_class.new.execute(project_data: project_to_convert)
 
     expect(converted_project).to eq(project_to_convert)
   end

--- a/spec/unit/ui/use_case/create_project_spec.rb
+++ b/spec/unit/ui/use_case/create_project_spec.rb
@@ -3,9 +3,15 @@
 describe UI::UseCase::CreateProject do
   context 'Example one' do
     let(:create_project_spy) { spy(execute: { id: 1 }) }
-    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:convert_ui_hif_project_spy) { spy(execute: { cattos: 'purr' }) }
+    let(:use_case) do
+      described_class.new(
+        create_project: create_project_spy,
+        convert_ui_hif_project: convert_ui_hif_project_spy
+      )
+    end
     let(:response) do
-      use_case.execute(type: 'hif', name: 'Cats', baseline: { Cats: 'purr' }) 
+      use_case.execute(type: 'hif', name: 'Cats', baseline: { Cats: 'purr' })
     end
 
     before do
@@ -28,20 +34,54 @@ describe UI::UseCase::CreateProject do
       )
     end
 
-    it 'Calls execute on the create project usecase with the baseline' do
-      expect(create_project_spy).to(
-        have_received(:execute).with(hash_including(baseline: { Cats: 'purr' }))
-      )
-    end
-
     it 'Returns the id from create project' do
       expect(response).to eq(id: 1)
+    end
+
+    context 'Given hif project' do
+      it 'Calls execute on the convert use case' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Passes the project data to the converter' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute).with(
+          project_data: { Cats: 'purr' }
+        )
+      end
+
+      it 'Creates the project with the converted data' do
+        expect(create_project_spy).to(
+          have_received(:execute).with(hash_including(baseline: { cattos: 'purr' }))
+        )
+      end
+    end
+
+    context 'Given non hif project' do
+      let(:response) do
+        use_case.execute(type: 'laac', name: 'Cats', baseline: { Cats: 'purr' })
+      end
+
+      it 'Does not call execute on the convert use case' do
+        expect(convert_ui_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Creates the project with the non-converted data' do
+        expect(create_project_spy).to(
+          have_received(:execute).with(hash_including(baseline: { Cats: 'purr' }))
+        )
+      end
     end
   end
 
   context 'Example two' do
     let(:create_project_spy) { spy(execute: { id: 5 }) }
-    let(:use_case) { described_class.new(create_project: create_project_spy) }
+    let(:convert_ui_hif_project_spy) { spy(execute: { dogs: 'woof' }) }
+    let(:use_case) do
+      described_class.new(
+        create_project: create_project_spy,
+        convert_ui_hif_project: convert_ui_hif_project_spy
+      )
+    end
     let(:response) do
       use_case.execute(type: 'laac', name: 'Dogs', baseline: { doggos: 'woof' })
     end
@@ -78,6 +118,40 @@ describe UI::UseCase::CreateProject do
 
     it 'Returns the id from create project' do
       expect(response).to eq(id: 5)
+    end
+
+    context 'Given hif project' do
+      let(:response) do
+        use_case.execute(type: 'hif', name: 'Dogs', baseline: { doggos: 'woof' })
+      end
+
+      it 'Calls execute on the convert use case' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Passes the project data to the converter' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute).with(
+          project_data: { doggos: 'woof' }
+        )
+      end
+
+      it 'Creates the project with the converted data' do
+        expect(create_project_spy).to(
+          have_received(:execute).with(hash_including(baseline: { dogs: 'woof' }))
+        )
+      end
+    end
+
+    context 'Given non hif project' do
+      it 'Does not call execute on the convert use case' do
+        expect(convert_ui_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Creates the project with the non-converted data' do
+        expect(create_project_spy).to(
+          have_received(:execute).with(hash_including(baseline: { doggos: 'woof' }))
+        )
+      end
     end
   end
 end

--- a/spec/unit/ui/use_case/get_project_spec.rb
+++ b/spec/unit/ui/use_case/get_project_spec.rb
@@ -12,7 +12,13 @@ describe UI::UseCase::GetProject do
         }
       )
     end
-    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:convert_core_hif_project_spy) { spy(execute: { building2: 'a house' }) }
+    let(:use_case) do
+      described_class.new(
+        find_project: find_project_spy,
+        convert_core_hif_project: convert_core_hif_project_spy
+      )
+    end
     let(:response) { use_case.execute(id: 1) }
 
     before do
@@ -35,12 +41,47 @@ describe UI::UseCase::GetProject do
       expect(response[:type]).to eq('hif')
     end
 
-    it 'Return the type from find project' do
-      expect(response[:data]).to eq(building1: 'a house')
-    end
-
     it 'Return the status from find project' do
       expect(response[:status]).to eq('Draft')
+    end
+
+    context 'Given a hif project' do
+      it 'Calls execute on the convert core hif project use case' do
+        expect(convert_core_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Passes the project data to the converter' do
+        expect(convert_core_hif_project_spy).to(
+          have_received(:execute).with(
+            project_data: { building1: 'a house' }
+          )
+        )
+      end
+
+      it 'Returns the converted data from find project' do
+        expect(response[:data]).to eq(building2: 'a house')
+      end
+    end
+
+    context 'Given a non hif project' do
+      let(:find_project_spy) do
+        spy(
+          execute: {
+            name: 'Big Buildings',
+            type: 'ac',
+            data: { building1: 'a house' },
+            status: 'Draft'
+          }
+        )
+      end
+
+      it 'Does not execute the converted' do
+        expect(convert_core_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Returns the original data' do
+        expect(response[:data]).to eq(building1: 'a house')
+      end
     end
   end
 
@@ -49,13 +90,19 @@ describe UI::UseCase::GetProject do
       spy(
         execute: {
           name: 'Big ol woof',
-          type: 'dogs',
+          type: 'hif',
           data: { noise: 'bark' },
           status: 'Barking'
         }
       )
     end
-    let(:use_case) { described_class.new(find_project: find_project_spy) }
+    let(:convert_core_hif_project_spy) { spy(execute: { noiseMade: 'bark' }) }
+    let(:use_case) do
+      described_class.new(
+        find_project: find_project_spy,
+        convert_core_hif_project: convert_core_hif_project_spy
+      )
+    end
     let(:response) { use_case.execute(id: 5) }
 
     before do
@@ -75,15 +122,50 @@ describe UI::UseCase::GetProject do
     end
 
     it 'Return the type from find project' do
-      expect(response[:type]).to eq('dogs')
-    end
-
-    it 'Return the type from find project' do
-      expect(response[:data]).to eq(noise: 'bark')
+      expect(response[:type]).to eq('hif')
     end
 
     it 'Return the status from find project' do
       expect(response[:status]).to eq('Barking')
+    end
+
+    context 'Given a hif project' do
+      it 'Calls execute on the convert core hif project use case' do
+        expect(convert_core_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Passes the project data to the converter' do
+        expect(convert_core_hif_project_spy).to(
+          have_received(:execute).with(
+            project_data: { noise: 'bark' }
+          )
+        )
+      end
+
+      it 'Returns the converted data from find project' do
+        expect(response[:data]).to eq(noiseMade: 'bark')
+      end
+    end
+
+    context 'Given a non hif project' do
+      let(:find_project_spy) do
+        spy(
+          execute: {
+            name: 'Big Buildings',
+            type: 'cattos',
+            data: { noise: 'bark' },
+            status: 'Draft'
+          }
+        )
+      end
+
+      it 'Does not execute the converted' do
+        expect(convert_core_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Returns the original data' do
+        expect(response[:data]).to eq(noise: 'bark')
+      end
     end
   end
 end

--- a/spec/unit/ui/use_case/update_project_spec.rb
+++ b/spec/unit/ui/use_case/update_project_spec.rb
@@ -3,8 +3,16 @@
 describe UI::UseCase::UpdateProject do
   context 'Example one' do
     let(:update_project_spy) { spy(execute: { successful: true }) }
-    let(:use_case) { described_class.new(update_project: update_project_spy) }
-    let(:response) { use_case.execute(id: 7, data: { cat: 'meow' }) }
+    let(:convert_ui_hif_project_spy) { spy(execute: { catto: 'meow' }) }
+    let(:use_case) do
+      described_class.new(
+        update_project: update_project_spy,
+        convert_ui_hif_project: convert_ui_hif_project_spy
+      )
+    end
+    let(:response) do
+      use_case.execute(id: 7, type: 'hif', data: { cat: 'meow' })
+    end
 
     before { response }
 
@@ -18,25 +26,63 @@ describe UI::UseCase::UpdateProject do
       )
     end
 
-    it 'Passes the update project use case the project data' do
-      expect(update_project_spy).to(
-        have_received(:execute).with(
-          hash_including(
-            project_data: { cat: 'meow' }
-          )
-        )
-      )
-    end
-
     it 'Returns successful if successful' do
       expect(response).to eq(successful: true)
+    end
+
+    context 'Given a hif project' do
+      it 'Calls execute on the convert usecase' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Converts the project data' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute).with(
+          project_data: { cat: 'meow' }
+        )
+      end
+
+      it 'Passes the update project use case the converted project data' do
+        expect(update_project_spy).to(
+          have_received(:execute).with(
+            hash_including(
+              project_data: { catto: 'meow' }
+            )
+          )
+        )
+      end
+    end
+
+    context 'Given a non-hif project' do
+      let(:response) do
+        use_case.execute(id: 7, type: 'ac', data: { cat: 'meow' })
+      end
+
+      it 'Does not call execute on the convert usecase' do
+        expect(convert_ui_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Passes the update project use case the non-converted project data' do
+        expect(update_project_spy).to(
+          have_received(:execute).with(
+            hash_including(
+              project_data: { cat: 'meow' }
+            )
+          )
+        )
+      end
     end
   end
 
   context 'Example two' do
     let(:update_project_spy) { spy(execute: { successful: false }) }
-    let(:use_case) { described_class.new(update_project: update_project_spy) }
-    let(:response) { use_case.execute(id: 2, data: { dog: 'woof' }) }
+    let(:convert_ui_hif_project_spy) { spy(execute: { doggo: 'woof' }) }
+    let(:use_case) do
+      described_class.new(
+        update_project: update_project_spy,
+        convert_ui_hif_project: convert_ui_hif_project_spy
+      )
+    end
+    let(:response) { use_case.execute(id: 2, type: 'hif', data: { dog: 'woof' }) }
 
     before { response }
 
@@ -50,18 +96,50 @@ describe UI::UseCase::UpdateProject do
       )
     end
 
-    it 'Passes the update project use case the project data' do
-      expect(update_project_spy).to(
-        have_received(:execute).with(
-          hash_including(
-            project_data: { dog: 'woof' }
-          )
-        )
-      )
-    end
-
     it 'Returns unsuccessful if unsuccessful' do
       expect(response).to eq(successful: false)
+    end
+
+    context 'Given a hif project' do
+      it 'Calls execute on the convert usecase' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute)
+      end
+
+      it 'Converts the project data' do
+        expect(convert_ui_hif_project_spy).to have_received(:execute).with(
+          project_data: { dog: 'woof' }
+        )
+      end
+
+      it 'Passes the update project use case the converted project data' do
+        expect(update_project_spy).to(
+          have_received(:execute).with(
+            hash_including(
+              project_data: { doggo: 'woof' }
+            )
+          )
+        )
+      end
+    end
+
+    context 'Given a non-hif project' do
+      let(:response) do
+        use_case.execute(id: 7, type: 'ac', data: { dog: 'woof' })
+      end
+
+      it 'Does not call execute on the convert usecase' do
+        expect(convert_ui_hif_project_spy).not_to have_received(:execute)
+      end
+
+      it 'Passes the update project use case the non-converted project data' do
+        expect(update_project_spy).to(
+          have_received(:execute).with(
+            hash_including(
+              project_data: { dog: 'woof' }
+            )
+          )
+        )
+      end
     end
   end
 end

--- a/spec/web_routes/update_project_spec.rb
+++ b/spec/web_routes/update_project_spec.rb
@@ -4,6 +4,7 @@ require 'rspec'
 require_relative 'delivery_mechanism_spec_helper'
 
 describe 'Updating a project' do
+  let(:get_project_spy) { spy(execute: { type: 'hif' })}
   let(:update_project_spy) { spy(execute: { successful: true }) }
   let(:create_new_project_spy) { spy(execute: project_id) }
   let(:project_id) { 1 }
@@ -29,6 +30,11 @@ describe 'Updating a project' do
   end
 
   before do
+    stub_const(
+      'UI::UseCase::GetProject',
+      double(new: get_project_spy)
+    )
+
     stub_const(
       'UI::UseCase::UpdateProject',
       double(new: update_project_spy)
@@ -67,6 +73,7 @@ describe 'Updating a project' do
     before do
       post '/project/update', {
         project_id: project_id,
+        project_type: 'hif',
         project_data: new_project_data[:baselineData]
       }.to_json
     end
@@ -75,10 +82,17 @@ describe 'Updating a project' do
       expect(last_response.status).to eq(200)
     end
 
+    it 'Should get the project for the id' do
+      expect(get_project_spy).to(
+        have_received(:execute).with(id: project_id)
+      )
+    end
+
     it 'should update project data for id' do
       expect(update_project_spy).to(
         have_received(:execute).with(
           id: project_id,
+          type: 'hif',
           data: { cats: 'quack', dogs: 'baa' }
         )
       )


### PR DESCRIPTION
WHAT
- Adds converts for hif projects that sit between the UI/Core layer

WHY
- To allow for easier changing of the schema for the UI without requiring DB changes

**OUTSTANDING WORK**
- Support for AC
  - As this is still in heavy development I have just ignored converting AC for the moment
- Schemas for the UI layer need to be returned over the internal schemas
  - as there is no difference yet this can be done in a subsequent PR