### PR TITLE
Move environment for return tabs to docker-compose

### DIFF
--- a/bin/serve.sh
+++ b/bin/serve.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env ash
 
-export OUTPUTS_FORECAST_TAB=yes
-
 _term() {
   echo "Caught SIGTERM signal!"
   kill -TERM "$rack" 2>/dev/null

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,11 @@ services:
       HMAC_SECRET: 'E'
       ADMIN_HTTP_API_KEY: 'supersecret'
       BI_HTTP_API_KEY: 'supersecret'
+      OUTPUTS_FORECAST_TAB: 'yes'
+      CONFIRMATION_TAB: 'yes'
+      S151_TAB: 'yes'
+      RM_MONTHLY_CATCHUP_TAB: 'yes'
+      OUTPUTS_ACTUALS_TAB: 'yes'
 
   notify_simulator:
     build: .


### PR DESCRIPTION
WHAT: Moves the triggers for the additional return tags to the docker-compose file
WHY: So that the tabs can be tested locally.