### PR TITLE
Populate size in hectares from the baseline and mark as readonly

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -1298,7 +1298,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
                           title: 'Total',
                           type: 'string',
                           sourceKey: %i[baseline_data fundingProfiles total],
-                          readonly: true, 
+                          readonly: true,
                           currency: true
                         }
                       }
@@ -2322,7 +2322,9 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
         },
         size: {
           type: 'string',
-          title: 'Size (hectares)'
+          title: 'Size (hectares)',
+          readonly: true,
+          sourceKey: %i[baseline_data summary totalArea]
         },
         previousStarts: {
           type: 'string',

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -139,7 +139,8 @@
     ],
     "noOfUnits": [
       "123"
-    ]
+    ],
+    "size": "10"
   },
   "s151Confirmation": {
     "hifFunding": {

--- a/spec/fixtures/hif_updated_return.json
+++ b/spec/fixtures/hif_updated_return.json
@@ -146,7 +146,8 @@
   },
   "outputsActuals": {
     "localAuthority": ["Local Authority"],
-    "noOfUnits": ["123"]
+    "noOfUnits": ["123"],
+    "size": "10"
   },
   "s151Confirmation": {
     "hifFunding": {

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -144,7 +144,8 @@
     ],
     "noOfUnits": [
       "123"
-    ]
+    ],
+    "size": "10"
   },
   "s151Confirmation": {
     "hifFunding": {


### PR DESCRIPTION
Size of the site in hectares is already filled in on the summary of the baseline.
As such, this field is now populated from that field and marked as read-only to prevent inaccurate data.