### PR TITLE
Add sourceKey reference to hifTotalFundingRequest to prepopulate data

### DIFF
--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -1789,7 +1789,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
             hifTotalFundingRequest: {
               type: 'string',
               title: 'HIF Total Funding Request',
-              sourceKey: %i[return_data fundingProfiles totalHIFGrant],
+              sourceKey: %i[baseline_data summary hifFundingAmount],
               readonly: true,
               hidden: true,
               currency: true

--- a/lib/local_authority/gateway/in_memory_return_template.rb
+++ b/lib/local_authority/gateway/in_memory_return_template.rb
@@ -1789,6 +1789,7 @@ class LocalAuthority::Gateway::InMemoryReturnTemplate
             hifTotalFundingRequest: {
               type: 'string',
               title: 'HIF Total Funding Request',
+              sourceKey: %i[return_data fundingProfiles totalHIFGrant],
               readonly: true,
               hidden: true,
               currency: true

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -76,6 +76,7 @@ describe 'Interacting with a HIF Return from the UI' do
       return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:status] = 'Delayed'
       return_data[:infrastructures][0][:planning][:outlinePlanning][:planningSubmitted][:reason] = 'Distracted by kittens'
       return_data[:s151][:claimSummary][:hifTotalFundingRequest] = '10000'
+      return_data[:s151Confirmation][:hifFunding][:hifTotalFundingRequest] = '10000'
       dependency_factory.get_use_case(:ui_update_return).execute(return_id: return_id, return_data: return_data)
 
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)[:updates].last

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -154,6 +154,7 @@
   },
   "s151Confirmation": {
     "hifFunding": {
+      "hifTotalFundingRequest": "10000",
       "hifFundingProfile": [
         {
           "period": "2019/2020",

--- a/spec/fixtures/hif_saved_base_return.json
+++ b/spec/fixtures/hif_saved_base_return.json
@@ -195,7 +195,7 @@
   },
   "s151Confirmation": {
     "hifFunding": {
-      "hifTotalFundingRequest": null,
+      "hifTotalFundingRequest": "10000",
       "changesToRequest": {
         "changesToRequestConfirmation": null,
         "requestedAmount": null,

--- a/spec/fixtures/hif_updated_return.json
+++ b/spec/fixtures/hif_updated_return.json
@@ -20,7 +20,7 @@
         },
         "planningNotGranted": {
           "fieldOne": {
-            "varianceCalculations" : {
+            "varianceCalculations": {
               "varianceAgainstLastReturn": {
                 "varianceLastReturnFullPlanningPermissionSubmitted": null
               }
@@ -134,7 +134,7 @@
     "changeRequired": null,
     "reasonForRequest": null,
     "mitigationInPlace": null,
-    "requestedProfiles": [{ "period": "2019/2020" }, {"period": null}]
+    "requestedProfiles": [{ "period": "2019/2020" }, { "period": null }]
   },
   "fundingPackages": [
     {
@@ -206,13 +206,13 @@
   },
   "s151Confirmation": {
     "hifFunding": {
-      "hifTotalFundingRequest": null,
+      "hifTotalFundingRequest": "10000",
       "changesToRequest": {
         "changesToRequestConfirmation": null,
         "requestedAmount": null,
         "reasonForRequest": null,
         "varianceFromBaseline": null,
-        "varianceFromBaselinePercent" : null,
+        "varianceFromBaselinePercent": null,
         "mitigationInPlace": null
       },
       "hifFundingProfile": [

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -159,6 +159,7 @@
   },
   "s151Confirmation": {
     "hifFunding": {
+      "hifTotalFundingRequest": "10000",
       "hifFundingProfile": [
         {
           "period": "2019/2020",


### PR DESCRIPTION
WHAT:
Adds a sourceKey to the s151 Confirmation > HIF Total Funding Request field to pull data from HIF Grant Expenditure > Total HIF Grant.

WHY:
Prevent inaccurate duplication of data via human input.