### PR TITLE
Calculate variance of s151 spending amounts

### DIFF
--- a/lib/local_authority/use_case/calculate_hif_return.rb
+++ b/lib/local_authority/use_case/calculate_hif_return.rb
@@ -58,24 +58,24 @@ class LocalAuthority::UseCase::CalculateHIFReturn
     return s151 if s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast).nil?
     return s151 if s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual).nil?
 
-    forecast = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast).gsub(/[\s,]/ ,"")
-    actual = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual).gsub(/[\s,]/ ,"")
-    if (difference(forecast.to_i, actual.to_i).zero?)
+    forecast = convert_to_integer(s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast))
+    actual = convert_to_integer(s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual))
+    if ((forecast - actual).zero?)
       s151[:supportingEvidence][:lastQuarterMonthSpend][:hasVariance] = 'No'
     else
       s151[:supportingEvidence][:lastQuarterMonthSpend][:hasVariance] = 'Yes'
-      s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount] = difference(forecast.to_i, actual.to_i).to_s
-      s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage] = percentage_difference(forecast.to_i, actual.to_i).to_s
+      s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount] = (forecast - actual).to_s
+      s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage] = percentage_difference(forecast, actual).to_s
     end
     s151
   end
 
-  def percentage_difference(base, different)
-    (difference(base, different) * 100)/base
+  def convert_to_integer(number)
+    number.sub(/[\s,]/ ,"").to_i
   end
 
-  def difference(base, different)
-    base - different
+  def percentage_difference(base, different)
+    ((base - different) * 100)/base
   end
 
   def current_return(return_data, index)

--- a/lib/local_authority/use_case/calculate_hif_return.rb
+++ b/lib/local_authority/use_case/calculate_hif_return.rb
@@ -55,9 +55,15 @@ class LocalAuthority::UseCase::CalculateHIFReturn
   end
 
   def s151_calculations(s151)
-    forecast = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast)
-    actual = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual)
-    unless (forecast.nil? || actual.nil?)
+    return s151 if s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast).nil?
+    return s151 if s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual).nil?
+
+    forecast = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :forecast).gsub(/[\s,]/ ,"")
+    actual = s151.dig(:supportingEvidence, :lastQuarterMonthSpend, :actual).gsub(/[\s,]/ ,"")
+    if (difference(forecast.to_i, actual.to_i).zero?)
+      s151[:supportingEvidence][:lastQuarterMonthSpend][:hasVariance] = 'No'
+    else
+      s151[:supportingEvidence][:lastQuarterMonthSpend][:hasVariance] = 'Yes'
       s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount] = difference(forecast.to_i, actual.to_i).to_s
       s151[:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage] = percentage_difference(forecast.to_i, actual.to_i).to_s
     end

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -1835,14 +1835,16 @@
                         {
                           "properties": {
                             "hasVariance": { "enum": ["Yes"] },
-                            "varianceAgainstForecastAmount": {
+                            "varianceAgainstForcastAmount": {
                               "title": "Variance Against Forecast",
                               "type": "string",
-                              "currency": true
+                              "currency": true,
+                              "readonly": true
                             },
-                            "varianceAgainstForecastPercentage": {
+                            "varianceAgainstForcastPercentage": {
                               "title": "Variance Against Forecast",
                               "type": "string",
+                              "readonly": true,
                               "percentage": true
                             },
                             "varianceReason": {

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -1815,46 +1815,46 @@
                   "type": "string",
                   "currency": true
                 },
-                "variance": {
-                  "title": "",
-                  "type": "object",
-                  "properties": {
-                    "hasVariance": {
-                      "title": "Does this vary to the forecasted amount?",
-                      "type": "string",
-                      "radio": true,
-                      "enum": ["Yes", "No"]
-                    }
-                  },
-                  "dependencies": {
-                    "hasVariance": {
-                      "oneOf": [
-                        {
-                          "properties": { "hasVariance": { "enum": ["No"] } }
-                        },
-                        {
-                          "properties": {
-                            "hasVariance": { "enum": ["Yes"] },
-                            "varianceAgainstForcastAmount": {
-                              "title": "Variance Against Forecast",
-                              "type": "string",
-                              "currency": true,
-                              "readonly": true
-                            },
-                            "varianceAgainstForcastPercentage": {
-                              "title": "Variance Against Forecast",
-                              "type": "string",
-                              "readonly": true,
-                              "percentage": true
-                            },
-                            "varianceReason": {
-                              "title": "Reason for Variance",
-                              "type": "string"
-                            }
+                "hasVariance": {
+                  "title": "Does this vary to the forecasted amount?",
+                  "type": "string",
+                  "readonly": true,
+                  "enum": ["Yes", "No"]  
+                },
+                "dependencies": {
+                  "hasVariance": {
+                    "oneOf": [
+                      {
+                        "properties": {
+                          "hasVariance": {
+                            "enum": ["No"]
                           }
                         }
-                      ]
-                    }
+                      },
+                      {
+                        "properties": {
+                          "hasVariance": {
+                            "enum": ["Yes"]
+                          },
+                          "varianceAgainstForcastAmount": {
+                            "title": "Variance Against Forecast",
+                            "type": "string",
+                            "currency": true,
+                            "readonly": true
+                          },
+                          "varianceAgainstForcastPercentage": {
+                            "title": "Percentage Variance Against Forecast",
+                            "type": "string",
+                            "readonly": true,
+                            "percentage": true
+                          },
+                          "varianceReason": {
+                            "title": "Reason for Variance",
+                            "type": "string"
+                          }
+                        }
+                      }
+                    ]
                   }
                 }
               }

--- a/lib/ui/use_case/convert_core_hif_return.rb
+++ b/lib/ui/use_case/convert_core_hif_return.rb
@@ -499,9 +499,8 @@ class UI::UseCase::ConvertCoreHIFReturn
       @converted_return[:s151][:supportingEvidence][:lastQuarterMonthSpend] = {
         forecast: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:forecast],
         actual: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:actual],
-        hasVariance: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:hasVariance],
-        varianceAgainstForecastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount],
-        varianceAgainstForecastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage]
+        varianceAgainstForcastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount],
+        varianceAgainstForcastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage]
       }
     end
 

--- a/lib/ui/use_case/convert_core_hif_return.rb
+++ b/lib/ui/use_case/convert_core_hif_return.rb
@@ -499,6 +499,7 @@ class UI::UseCase::ConvertCoreHIFReturn
       @converted_return[:s151][:supportingEvidence][:lastQuarterMonthSpend] = {
         forecast: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:forecast],
         actual: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:actual],
+        hasVariance: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:hasVariance],
         varianceAgainstForcastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount],
         varianceAgainstForcastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage]
       }

--- a/lib/ui/use_case/convert_ui_hif_return.rb
+++ b/lib/ui/use_case/convert_ui_hif_return.rb
@@ -488,9 +488,8 @@ class UI::UseCase::ConvertUIHIFReturn
       @converted_return[:s151][:supportingEvidence][:lastQuarterMonthSpend] = {
         forecast: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:forecast],
         actual: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:actual],
-        hasVariance: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:hasVariance],
-        varianceAgainstForcastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForecastAmount],
-        varianceAgainstForcastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForecastPercentage]
+        varianceAgainstForcastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount],
+        varianceAgainstForcastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage]
       }
     end
 

--- a/lib/ui/use_case/convert_ui_hif_return.rb
+++ b/lib/ui/use_case/convert_ui_hif_return.rb
@@ -488,6 +488,7 @@ class UI::UseCase::ConvertUIHIFReturn
       @converted_return[:s151][:supportingEvidence][:lastQuarterMonthSpend] = {
         forecast: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:forecast],
         actual: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:actual],
+        hasVariance: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:hasVariance],
         varianceAgainstForcastAmount: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastAmount],
         varianceAgainstForcastPercentage: @return[:s151][:supportingEvidence][:lastQuarterMonthSpend][:varianceAgainstForcastPercentage]
       }

--- a/spec/acceptance/local_authority/calculate_hif_return_spec.rb
+++ b/spec/acceptance/local_authority/calculate_hif_return_spec.rb
@@ -20,7 +20,15 @@ describe 'Calculated return' do
             }
           }
         }
-      ]
+      ],
+      s151: {
+        supportingEvidence: {
+          lastQuarterMonthSpend: {
+            forecast: '6',
+            actual: '3',
+          }
+        }
+      }
     }
 
     secondary_return_input_data = {
@@ -36,7 +44,15 @@ describe 'Calculated return' do
             }
           }
         }
-      ]
+      ],
+      s151: {
+        supportingEvidence: {
+          lastQuarterMonthSpend: {
+            forecast: '6',
+            actual: '3'
+          }
+        }
+      }
     }
 
     expected_return_data = {
@@ -58,8 +74,19 @@ describe 'Calculated return' do
             }
           }
         }
-      ]
+      ],
+      s151: {
+        supportingEvidence: {
+          lastQuarterMonthSpend: {
+            forecast: '6',
+            actual: '3',
+            varianceAgainstForcastAmount: '3',
+            varianceAgainstForcastPercentage: '50'
+          }
+        }
+      }
     }
+
     project_id = get_use_case(:create_new_project).execute(
       name: 'dog project 1',
       type: 'hif',

--- a/spec/acceptance/local_authority/calculate_hif_return_spec.rb
+++ b/spec/acceptance/local_authority/calculate_hif_return_spec.rb
@@ -80,6 +80,7 @@ describe 'Calculated return' do
           lastQuarterMonthSpend: {
             forecast: '6',
             actual: '3',
+            hasVariance: 'Yes',
             varianceAgainstForcastAmount: '3',
             varianceAgainstForcastPercentage: '50'
           }

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -95,7 +95,7 @@ describe 'Interacting with a HIF Return from the UI' do
       return_id = dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: full_return_data)[:id]
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)[:updates].last
 
-      expect(created_return[:s151][:supportingEvidence]).to eq(full_return_data_after_calcs[:s151][:supportingEvidence])
+      expect(created_return[:outputsForecast]).to eq(full_return_data_after_calcs[:outputsForecast])
     end
 
     it 'Allows you to view multiple created returns' do

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -95,7 +95,7 @@ describe 'Interacting with a HIF Return from the UI' do
       return_id = dependency_factory.get_use_case(:ui_create_return).execute(project_id: project_id, data: full_return_data)[:id]
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)[:updates].last
 
-      expect(created_return[:infrastructures][0][:planning]).to eq(full_return_data_after_calcs[:infrastructures][0][:planning])
+      expect(created_return[:s151][:supportingEvidence]).to eq(full_return_data_after_calcs[:s151][:supportingEvidence])
     end
 
     it 'Allows you to view multiple created returns' do

--- a/spec/fixtures/hif_return_core.json
+++ b/spec/fixtures/hif_return_core.json
@@ -382,6 +382,7 @@
       "lastQuarterMonthSpend": {
         "forecast": "500",
         "actual": "400",
+        "hasVariance": "No",
         "varianceAgainstForcastAmount": "456728",
         "varianceAgainstForcastPercentage": "123456"
       },

--- a/spec/fixtures/hif_return_core.json
+++ b/spec/fixtures/hif_return_core.json
@@ -380,9 +380,8 @@
     },
     "supportingEvidence": {
       "lastQuarterMonthSpend": {
-        "forecast": "Monneyyy",
-        "actual": "Less money?",
-        "hasVariance": "yes",
+        "forecast": "500",
+        "actual": "400",
         "varianceAgainstForcastAmount": "456728",
         "varianceAgainstForcastPercentage": "123456"
       },

--- a/spec/fixtures/hif_return_ui.json
+++ b/spec/fixtures/hif_return_ui.json
@@ -392,6 +392,7 @@
       "lastQuarterMonthSpend": {
         "forecast": "500",
         "actual": "400",
+        "hasVariance": "No",
         "varianceAgainstForcastAmount": "456728",
         "varianceAgainstForcastPercentage": "123456"
       },

--- a/spec/fixtures/hif_return_ui.json
+++ b/spec/fixtures/hif_return_ui.json
@@ -390,11 +390,10 @@
     },
     "supportingEvidence": {
       "lastQuarterMonthSpend": {
-        "forecast": "Monneyyy",
-        "actual": "Less money?",
-        "hasVariance": "yes",
-        "varianceAgainstForecastAmount": "456728",
-        "varianceAgainstForecastPercentage": "123456"
+        "forecast": "500",
+        "actual": "400",
+        "varianceAgainstForcastAmount": "456728",
+        "varianceAgainstForcastPercentage": "123456"
       },
       "evidenceOfSpendPastQuarter": "Much",
       "breakdownOfNextQuarterSpend": {

--- a/spec/fixtures/hif_return_ui_after_calcs.json
+++ b/spec/fixtures/hif_return_ui_after_calcs.json
@@ -399,10 +399,10 @@
     },
     "supportingEvidence": {
       "lastQuarterMonthSpend": {
-        "forecast": "Monneyyy",
-        "actual": "Less money?",
-        "varianceAgainstForcastAmount": "456728",
-        "varianceAgainstForcastPercentage": "123456"
+        "forecast": "500",
+        "actual": "400",
+        "varianceAgainstForcastAmount": "100",
+        "varianceAgainstForcastPercentage": "20"
       },
       "evidenceOfSpendPastQuarter": "Much",
       "breakdownOfNextQuarterSpend": {

--- a/spec/fixtures/hif_return_ui_after_calcs.json
+++ b/spec/fixtures/hif_return_ui_after_calcs.json
@@ -323,7 +323,7 @@
       ]
     },
     "inYearHousingCompletions": {
-      "risksToSchieving": "none"
+      "risksToAchieving": "none"
     }
   },
   "s151Confirmation": {
@@ -401,6 +401,7 @@
       "lastQuarterMonthSpend": {
         "forecast": "500",
         "actual": "400",
+        "hasVariance": "Yes",
         "varianceAgainstForcastAmount": "100",
         "varianceAgainstForcastPercentage": "20"
       },

--- a/spec/fixtures/hif_saved_base_return.json
+++ b/spec/fixtures/hif_saved_base_return.json
@@ -284,8 +284,8 @@
         "forecast": null,
         "actual": null,
         "hasVariance": null,
-        "varianceAgainstForecastAmount": null,
-        "varianceAgainstForecastPercentage": null
+        "varianceAgainstForcastAmount": null,
+        "varianceAgainstForcastPercentage": null
       },
       "evidenceOfSpendPastQuarter": null
     },

--- a/spec/unit/local_authority/use_case/calculate_hif_return_spec.rb
+++ b/spec/unit/local_authority/use_case/calculate_hif_return_spec.rb
@@ -471,6 +471,7 @@ describe LocalAuthority::UseCase::CalculateHIFReturn do
                 lastQuarterMonthSpend: {
                   forecast: '10000',
                   actual: '9000',
+                  hasVariance: 'Yes',
                   varianceAgainstForcastAmount: '1000',
                   varianceAgainstForcastPercentage: '10' 
                 }
@@ -507,9 +508,10 @@ describe LocalAuthority::UseCase::CalculateHIFReturn do
             s151: {
               supportingEvidence: {
                 lastQuarterMonthSpend: {
-                  forecast: '25',
-                  actual: '5',
-                  varianceAgainstForcastAmount: '20',
+                  forecast: '25,000',
+                  actual: '5,000',
+                  hasVariance: 'Yes',
+                  varianceAgainstForcastAmount: '20000',
                   varianceAgainstForcastPercentage: '80' 
                 }
               }
@@ -520,8 +522,8 @@ describe LocalAuthority::UseCase::CalculateHIFReturn do
             s151: {
               supportingEvidence: {
                 lastQuarterMonthSpend: {
-                  forecast: '25',
-                  actual: '5'
+                  forecast: '25,000',
+                  actual: '5,000'
                 }
               }
             }
@@ -609,6 +611,82 @@ describe LocalAuthority::UseCase::CalculateHIFReturn do
           )
 
           expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+    end
+
+    context ' in S151:supportingEvidence:lastQuarterMonthSpend forecast and amount are the same' do
+      context 'example one' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            infrastructures: [],
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '7',
+                  actual: '7',
+                  hasVariance: 'No'
+                }
+              }
+            }
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '7',
+                  actual: '7'
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+
+      context 'example two' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '10',
+                  actual: '10',
+                  hasVariance: 'No'
+                }
+              }
+            },
+            infrastructures: []
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '10',
+                  actual: '10'
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return][:s151]).to eq(expected_return_data[:s151])
         end
       end
     end

--- a/spec/unit/local_authority/use_case/calculate_hif_return_spec.rb
+++ b/spec/unit/local_authority/use_case/calculate_hif_return_spec.rb
@@ -459,4 +459,158 @@ describe LocalAuthority::UseCase::CalculateHIFReturn do
       end
     end
   end
+
+  context 'varianceAgainstForcast' do
+    context ' in S151:supportingEvidence:lastQuarterMonthSpend forecast and amount are present' do
+      context 'example one' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            infrastructures: [],
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '10000',
+                  actual: '9000',
+                  varianceAgainstForcastAmount: '1000',
+                  varianceAgainstForcastPercentage: '10' 
+                }
+              }
+            }
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '10000',
+                  actual: '9000'
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+
+      context 'example two' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            infrastructures: [],
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '25',
+                  actual: '5',
+                  varianceAgainstForcastAmount: '20',
+                  varianceAgainstForcastPercentage: '80' 
+                }
+              }
+            }
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: '25',
+                  actual: '5'
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+    end
+
+    context ' in S151:supportingEvidence:lastQuarterMonthSpend forecast and amount are not present' do
+      context 'example one' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            infrastructures: [],
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: nil,
+                  actual: nil,
+                }
+              }
+            }
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: nil,
+                  actual: nil
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+
+      context 'example two' do
+        it 'should return a propulated varianceAgainstForcast amount and percentage' do
+          expected_return_data = {
+            infrastructures: [],
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: nil,
+                  actual: nil,
+                }
+              }
+            }
+          }
+
+          return_data_with_no_calculations = {
+            s151: {
+              supportingEvidence: {
+                lastQuarterMonthSpend: {
+                  forecast: nil,
+                  actual: nil
+                }
+              }
+            }
+          }
+
+          previous_return = {}
+
+          return_data = use_case.execute(
+            return_data_with_no_calculations: return_data_with_no_calculations,
+            previous_return: previous_return
+          )
+
+          expect(return_data[:calculated_return]).to eq(expected_return_data)
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Added calculations for fields in S151 > Supporting Evidence > Last Quarter Month Spend to calculate the variance between forecast and actual (£ and %). 