### PR TITLE
Add ordering to updates_for method on sequel_return_update

### DIFF
--- a/lib/local_authority/gateway/sequel_return_update.rb
+++ b/lib/local_authority/gateway/sequel_return_update.rb
@@ -16,7 +16,7 @@ class LocalAuthority::Gateway::SequelReturnUpdate
   end
 
   def updates_for(return_id:)
-    @database[:return_updates].where(return_id: return_id).map { |row| row_to_return_update(row) }
+    @database[:return_updates].where(return_id: return_id).order(:id).map { |row| row_to_return_update(row) }
   end
 
   private


### PR DESCRIPTION
WHAT: Adds an order by to the map function
WHY: Postgres does not guarantee the order in which it returns data.