### PR TITLE
Add ui use case to get schema for returns

### DIFF
--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -102,7 +102,7 @@ module DeliveryMechanism
         return 404 if return_hash.empty?
 
         return_schema = @dependency_factory
-                        .get_use_case(:get_schema_for_return)
+                        .get_use_case(:ui_get_schema_for_return)
                         .execute(return_id: return_id)[:schema]
 
         response.body = {

--- a/lib/ui/gateway/schemas/ac_return.json
+++ b/lib/ui/gateway/schemas/ac_return.json
@@ -191,7 +191,7 @@
                           "baseline_data",
                           "outputs",
                           "mmcCategory",
-                          "categoryA"
+                          "catA"
                         ]
                       },
                       "latestEstimate": {
@@ -214,7 +214,7 @@
                           "baseline_data",
                           "outputs",
                           "mmcCategory",
-                          "categoryB"
+                          "catB"
                         ]
                       },
                       "latestEstimate": {
@@ -237,7 +237,7 @@
                           "baseline_data",
                           "outputs",
                           "mmcCategory",
-                          "categoryC"
+                          "catC"
                         ]
                       },
                       "latestEstimate": {
@@ -260,7 +260,7 @@
                           "baseline_data",
                           "outputs",
                           "mmcCategory",
-                          "categoryD"
+                          "catD"
                         ]
                       },
                       "latestEstimate": {
@@ -283,7 +283,7 @@
                           "baseline_data",
                           "outputs",
                           "mmcCategory",
-                          "categoryE"
+                          "catE"
                         ]
                       },
                       "latestEstimate": {
@@ -1945,6 +1945,7 @@
               "year": {
                 "type": "string",
                 "title": "Year",
+                "laReadOnly": true,                
                 "sourceKey": [
                   "baseline_data",
                   "financials",
@@ -1954,22 +1955,26 @@
               },
               "Q1Amount": {
                 "type": "string",
+                "laReadOnly": true,
                 "title": "First Quarter",
                 "currency": true
               },
               "Q2Amount": {
                 "type": "string",
                 "title": "Second Quarter",
+                "laReadOnly": true,
                 "currency": true
               },
               "Q3Amount": {
                 "type": "string",
                 "title": "Third Quarter",
+                "laReadOnly": true,
                 "currency": true
               },
               "Q4Amount": {
                 "type": "string",
                 "title": "Fourth Quarter",
+                "laReadOnly": true,
                 "currency": true
               },
               "total": {
@@ -2030,7 +2035,7 @@
         },
         "riskRating": {
           "type": "array",
-          "title": "Riak Rating",
+          "title": "Risk Rating",
           "quarterly": true,
           "items": {
             "type": "object",
@@ -2152,17 +2157,20 @@
             "TotalFundingRequest": {
               "type": "string",
               "title": "Total Funding Request",
+              "s151WriteOnly": true,
               "currency": true
             },
             "SpendToDate": {
               "type": "string",
               "hidden": true,
               "title": "Claimed to Date",
+              "s151WriteOnly": true,
               "currency": true
             },
             "AmountOfThisClaim": {
               "type": "string",
               "title": "Amount of this Claim",
+              "s151WriteOnly": true,
               "currency": true
             }
           }
@@ -2174,6 +2182,7 @@
             "evidenceOfSpendPastQuarter": {
               "title": "Evidence of Spend for the Past Quarter.",
               "type": "string",
+              "s151WriteOnly": true,
               "hidden": true
             },
             "breakdownOfNextQuarterSpend": {
@@ -2183,11 +2192,13 @@
                 "forecast": {
                   "title": "Forecasted Spend (£)",
                   "type": "string",
+                  "s151WriteOnly": true,
                   "currency": true
                 },
                 "descriptionOfSpend": {
                   "title": "Description of Spend",
                   "type": "string",
+                  "s151WriteOnly": true,
                   "extendedText": true
                 }
               }
@@ -2229,42 +2240,49 @@
                   "type": "string",
                   "title": "Estimated grant draw down profiles, including any changes requested to these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "milestoneDateEstimates": {
                   "type": "string",
                   "title": "Milestone date estimates, including any changes requested to these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "milestoneDatesAchieved": {
                   "type": "string",
                   "title": "Milestone dates achieved, including any evidence submitted to validate these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "housingOutputsEstimates": {
                   "type": "string",
                   "title": "Housing output profile estimates, including any changes requested to these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "housingClaimedAsAchieved": {
                   "type": "string",
                   "title": "Housing outputs claimed as achieved, including any evidence submitted to validate these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "receiptEstimates": {
                   "type": "string",
                   "title": "Receipt (income) estimates and actual income, including any evidence submitted to validate these",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 },
                 "noOtherGrantFundin": {
                   "type": "string",
                   "title": "That no other Grant Funding Agreement conditions have been breached.",
                   "enum": ["Yes", "No"],
+                  "s151WriteOnly": true,
                   "radio": true
                 }
               }
@@ -2276,6 +2294,7 @@
     "reviewAndAssurance": {
       "title": "Review and Assurance",
       "type": "object",
+      "laHidden": true,
       "properties": {
         "date": {
           "title": "Date of most recent meeting",

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -1786,12 +1786,14 @@
               "type": "string",
               "hidden": true,
               "title": "HIF Spend to Date",
+              "s151WriteOnly": true,
               "currency": true
             },
             "AmountOfThisClaim": {
               "type": "string",
               "title": "Amount of this Claim",
-              "currency": true
+              "currency": true,
+              "s151WriteOnly": true
             }
           }
         },
@@ -1810,7 +1812,7 @@
                     "return_data",
                     "s151",
                     "supportingEvidence",
-                    "lastQuarterMonthSpend",
+                    "breakdownOfNextQuarterSpend",
                     "forecast"
                   ],
                   "currency": true,
@@ -1818,49 +1820,54 @@
                 },
                 "actual": {
                   "title": "Actual Spend Last Quarter Month",
+                  "s151WriteOnly": true,
                   "type": "string",
                   "currency": true
                 },
-                "hasVariance": {
-                  "title": "Does this vary to the forecasted amount?",
-                  "type": "string",
-                  "readonly": true,
-                  "enum": ["Yes", "No"]  
-                },
-                "dependencies": {
-                  "hasVariance": {
-                    "oneOf": [
-                      {
-                        "properties": {
-                          "hasVariance": {
-                            "enum": ["No"]
+                "variance": {
+                  "title": "",
+                  "type": "object",
+                  "properties": {
+                    "hasVariance": {
+                      "title": "Does this vary to the forecasted amount?",
+                      "type": "string",
+                      "radio": true,
+                      "s151WriteOnly": true,
+                      "enum": ["Yes", "No"]
+                    }
+                  },
+                  "dependencies": {
+                    "hasVariance": {
+                      "oneOf": [
+                        {
+                          "properties": {
+                            "hasVariance": { "enum": ["No"] }
+                          }
+                        },
+                        {
+                          "properties": {
+                            "hasVariance": { "enum": ["Yes"] },
+                            "varianceAgainstForecastAmount": {
+                              "title": "Variance Against Forecast",
+                              "type": "string",
+                              "s151WriteOnly": true,
+                              "currency": true
+                            },
+                            "varianceAgainstForecastPercentage": {
+                              "title": "Variance Against Forecast",
+                              "type": "string",
+                              "s151WriteOnly": true,
+                              "percentage": true
+                            },
+                            "varianceReason": {
+                              "title": "Reason for Variance",
+                              "s151WriteOnly": true,
+                              "type": "string"
+                            }
                           }
                         }
-                      },
-                      {
-                        "properties": {
-                          "hasVariance": {
-                            "enum": ["Yes"]
-                          },
-                          "varianceAgainstForcastAmount": {
-                            "title": "Variance Against Forecast",
-                            "type": "string",
-                            "currency": true,
-                            "readonly": true
-                          },
-                          "varianceAgainstForcastPercentage": {
-                            "title": "Percentage Variance Against Forecast",
-                            "type": "string",
-                            "readonly": true,
-                            "percentage": true
-                          },
-                          "varianceReason": {
-                            "title": "Reason for Variance",
-                            "type": "string"
-                          }
-                        }
-                      }
-                    ]
+                      ]
+                    }
                   }
                 }
               }
@@ -1868,6 +1875,7 @@
             "evidenceOfSpendPastQuarter": {
               "title": "Evidence of Spend for the Past Quarter.",
               "type": "string",
+              "s151WriteOnly": true,
               "hidden": true
             },
             "breakdownOfNextQuarterSpend": {
@@ -1877,16 +1885,19 @@
                 "forecast": {
                   "title": "Forecasted Spend (£)",
                   "type": "string",
+                  "s151WriteOnly": true,
                   "currency": true
                 },
                 "descriptionOfSpend": {
                   "title": "Description of Spend",
                   "type": "string",
+                  "s151WriteOnly": true,
                   "extendedText": true
                 },
                 "evidenceOfSpendNextQuarter": {
                   "title": "Evidence of Spend for the Past Quarter.",
                   "type": "string",
+                  "s151WriteOnly": true,
                   "hidden": true
                 }
               }
@@ -1909,7 +1920,6 @@
               "title": "HIF Total Funding Request",
               "sourceKey": ["baseline_data", "summary", "hifFundingAmount"],
               "readonly": true,
-              "hidden": true,
               "currency": true
             },
             "changesToRequest": {
@@ -1920,6 +1930,7 @@
                   "type": "string",
                   "title": "Please confirm there are no changes to the total HIF request",
                   "radio": true,
+                  "s151WriteOnly": true,
                   "enum": ["Confirmed", "Changes Required"]
                 }
               },
@@ -1940,12 +1951,14 @@
                         },
                         "reasonForRequest": {
                           "type": "string",
-                          "title": "Reason for Request"
+                          "title": "Reason for Request",
+                          "s151WriteOnly": true
                         },
                         "requestedAmount": {
                           "type": "string",
                           "title": "Requested amount",
-                          "currency": true
+                          "currency": true,
+                          "s151WriteOnly": true
                         },
                         "varianceFromBaseline": {
                           "type": "string",
@@ -1963,6 +1976,7 @@
                         },
                         "mitigationInPlace": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Mitigation in place to reduce further slippage"
                         }
                       }
@@ -2126,7 +2140,61 @@
               "title": "Please confirm you are content with the submitted project cashflows",
               "type": "string",
               "radio": true,
+              "s151WriteOnly": true,
               "enum": ["Yes", "No"]
+            }
+          },
+          "dependencies": {
+            "changesToRequest": {
+              "oneOf": [
+                {
+                  "properties": {
+                    "changesToRequest": { "enum": ["Confirmed"] }
+                  }
+                },
+                {
+                  "properties": {
+                    "changesToRequest": { "enum": ["Changes Required"] },
+                    "reasonForRequest": {
+                      "type": "string",
+                      "s151WriteOnly": true,
+                      "title": "Reason for Request"
+                    },
+                    "requestedAmount": {
+                      "type": "string",
+                      "s151WriteOnly": true,
+                      "title": "Requested amount",
+                      "currency": true
+                    },
+                    "varianceFromBaseline": {
+                      "type": "string",
+                      "title": "Variance from Baseline",
+                      "readonly": true,
+                      "hidden": true,
+                      "currency": true
+                    },
+                    "varianceFromBaselinePercent": {
+                      "type": "string",
+                      "title": "Variance from Baseline",
+                      "percentage": true,
+                      "readonly": true,
+                      "hidden": true
+                    },
+                    "mitigationInPlace": {
+                      "type": "string",
+                      "title": "Mitigation in place to reduce further slippage",
+                      "s151WriteOnly": true
+                    },
+                    "amendmentConfirmation": {
+                      "title": "An amendment has been made to the forecast profile in this MR - please confirm you are content with this amendment",
+                      "type": "string",
+                      "s151WriteOnly": true,
+                      "radio": true,
+                      "enum": ["Yes", "No"]
+                    }
+                  }
+                }
+              ]
             }
           }
         },
@@ -2142,6 +2210,7 @@
                   "type": "string",
                   "title": "Please confirm that no changes are required to contractual milestones",
                   "radio": true,
+                  "s151WriteOnly": true,
                   "enum": ["Confirmed", "Changes Required"]
                 }
               },
@@ -2162,14 +2231,17 @@
                         },
                         "reasonForRequestOfMilestoneChange": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Reason for Request"
                         },
                         "requestedAmendments": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Requested amendments to milestones"
                         },
                         "mitigationInPlaceMilestone": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Mitigation in place to reduce further amendments"
                         }
                       }
@@ -2192,6 +2264,7 @@
                   "type": "string",
                   "title": "Please confirm that no changes are required to Funding End Date",
                   "radio": true,
+                  "s151WriteOnly": true,
                   "enum": ["Confirmed", "Changes Required"]
                 }
               },
@@ -2212,11 +2285,13 @@
                         },
                         "reasonForRequestOfDateChange": {
                           "type": "string",
-                          "title": "Reason for Request"
+                          "title": "Reason for Request",
+                          "s151WriteOnly": true
                         },
                         "requestedChangedEndDate": {
                           "type": "string",
-                          "title": "Requested new end date"
+                          "title": "Requested new end date",
+                          "s151WriteOnly": true
                         },
                         "varianceFromEndDateBaseline": {
                           "type": "string",
@@ -2226,6 +2301,7 @@
                         },
                         "mitigationInPlaceEndDate": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Mitigation in place to reduce further slippage"
                         }
                       }
@@ -2248,6 +2324,7 @@
                   "type": "string",
                   "title": "Please confirm that no changes are required to project completion date",
                   "radio": true,
+                  "s151WriteOnly": true,
                   "enum": ["Confirmed", "Changes Required"]
                 }
               },
@@ -2268,10 +2345,12 @@
                         },
                         "reasonForRequestOfLongstopChange": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Reason for Request"
                         },
                         "requestedLongstopEndDate": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Requested new end date"
                         },
                         "varianceFromLongStopBaseline": {
@@ -2282,6 +2361,7 @@
                         },
                         "mitigationInPlaceLongstopDate": {
                           "type": "string",
+                          "s151WriteOnly": true,
                           "title": "Mitigation in place to reduce further slippage"
                         }
                       }
@@ -2297,6 +2377,7 @@
                 "recoverFundingConfirmation": {
                   "type": "string",
                   "title": "Has any funding been recovered since last return?",
+                  "s151WriteOnly": true,
                   "radio": true,
                   "enum": ["Yes", "No"]
                 }
@@ -2311,6 +2392,7 @@
                           "type": "string",
                           "title": "Will/Has this been used on future housing?",
                           "radio": true,
+                          "s151WriteOnly": true,
                           "enum": ["Yes", "No"]
                         }
                       }

--- a/lib/ui/use_cases.rb
+++ b/lib/ui/use_cases.rb
@@ -85,6 +85,13 @@ class UI::UseCases
       )
     end
 
+    builder.define_use_case :ui_get_schema_for_return do
+      UI::UseCase::GetSchemaForReturn.new(
+        get_return: builder.get_use_case(:ui_get_return),
+        return_template: builder.get_gateway(:ui_return_schema)
+      )
+    end
+
     builder.define_use_case :ui_get_returns do
       UI::UseCase::GetReturns.new(
         get_returns: builder.get_use_case(:get_returns),

--- a/spec/web_routes/get_return_spec.rb
+++ b/spec/web_routes/get_return_spec.rb
@@ -17,7 +17,7 @@ describe 'Getting a return' do
     )
 
     stub_const(
-      'LocalAuthority::UseCase::GetSchemaForReturn',
+      'UI::UseCase::GetSchemaForReturn',
       double(new: get_schema_for_return_spy)
     )
 
@@ -48,7 +48,7 @@ describe 'Getting a return' do
         expect(get_return_spy).to have_received(:execute).with(id: 1)
       end
 
-      it 'passes data to GetSchemaForReturn' do
+      it 'passes data to UIGetSchemaForReturn' do
         expect(get_schema_for_return_spy).to(
           have_received(:execute).with(return_id: 1)
         )


### PR DESCRIPTION
Add a use case which gets the schema for the returns it lives in the UI folder and uses the UI gateway schema. perviously was pulling from local authority gateway.