### PR TITLE
Change the add user end point to except user roles.

### DIFF
--- a/lib/delivery_mechanism/controllers/post_project_to_users.rb
+++ b/lib/delivery_mechanism/controllers/post_project_to_users.rb
@@ -11,7 +11,7 @@ module DeliveryMechanism
         return 400 unless user_emails.instance_of? Array
 
         user_emails.each do |user_info|
-          @add_user_to_project.execute({ email: user_info[:email], project_id: params[:id].to_i })
+          @add_user_to_project.execute({ email: user_info[:email], role: user_info[:role], project_id: params[:id].to_i })
         end
         response.status = 200
         response

--- a/lib/homes_england/use_case/add_user_to_project.rb
+++ b/lib/homes_england/use_case/add_user_to_project.rb
@@ -3,11 +3,12 @@ class HomesEngland::UseCase::AddUserToProject
     @user_gateway = user_gateway
   end
 
-  def execute(email:, project_id:)
+  def execute(email:, role: nil, project_id:)
     user = @user_gateway.find_by(email: email)
     if user.nil?
       user = LocalAuthority::Domain::User.new.tap do |u|
         u.email = email.downcase
+        u.role = role
         u.projects = [project_id]
       end
       @user_gateway.create(user)

--- a/spec/unit/homes_england/use_case/add_user_to_project_spec.rb
+++ b/spec/unit/homes_england/use_case/add_user_to_project_spec.rb
@@ -2,19 +2,21 @@ describe HomesEngland::UseCase::AddUserToProject do
   let(:user_gateway) { spy(find_by: nil) }
   let(:use_case) { described_class.new(user_gateway: user_gateway) }
 
-  context 'calls the gateway for a user with a lowercase email with no permissions' do
+  context 'calls the gateway for a user with a lowercase email and a role' do
     it 'example 1' do
-      use_case.execute(email: 'Cat@caThouse.com', project_id: 1)
+      use_case.execute(email: 'Cat@caThouse.com', role: 'Homes England', project_id: 1)
       expect(user_gateway).to have_received(:create) do |user|
         expect(user.email).to eq('cat@cathouse.com')
+        expect(user.role).to eq('Homes England')
         expect(user.projects).to eq([1])
       end
     end
 
     it 'example 2' do
-      use_case.execute(email: 'dog@CAThouse.com', project_id: 4)
+      use_case.execute(email: 'dog@CAThouse.com', role: 'Local Authority', project_id: 4)
       expect(user_gateway).to have_received(:create) do |user|
         expect(user.email).to eq('dog@cathouse.com')
+        expect(user.role).to eq('Local Authority')
         expect(user.projects).to eq([4])
       end
     end

--- a/spec/web_routes/add_users_to_project_spec.rb
+++ b/spec/web_routes/add_users_to_project_spec.rb
@@ -86,10 +86,11 @@ describe 'Adding users to a project' do
 
       context 'it adds a single user' do
         example 'example 1' do
-          request_body = { users: [{ email: 'mt1@mt1.com' }] }
+          request_body = { users: [{ email: 'mt1@mt1.com', role: 'S151' }] }
           post('project/33/add_users', request_body.to_json)
           expect(add_user_to_project_usecase_spy).to have_received(:execute).with(
             project_id: 33,
+            role: 'S151',
             email: 'mt1@mt1.com'
           )
         end
@@ -99,22 +100,25 @@ describe 'Adding users to a project' do
           post('project/24/add_users', request_body.to_json)
           expect(add_user_to_project_usecase_spy).to have_received(:execute).with(
             project_id: 24,
+            role: nil,
             email: 'cat@mouse.com'
           )
         end
       end
 
       context 'when each entry in the body is non-empty' do
-        let(:request_body) { { users: [{ email: 'mt1@mt1.com' }, { email: 'mt2@mt2.com' }] } }
+        let(:request_body) { { users: [{ email: 'mt1@mt1.com', role: 'Homes England' }, { email: 'mt2@mt2.com', role: 'Local Authority' }] } }
 
         it 'execute AddUserToProject use case for each valid email' do
           post('project/33/add_users', request_body.to_json)
           expect(add_user_to_project_usecase_spy).to have_received(:execute).with(
             project_id: 33,
+            role: 'Homes England',
             email: 'mt1@mt1.com'
           )
           expect(add_user_to_project_usecase_spy).to have_received(:execute).with(
             project_id: 33,
+            role: 'Local Authority',
             email: 'mt2@mt2.com'
           )
         end


### PR DESCRIPTION
So that we can add users with roles to projects by calling the add users endpoint with:   { users: [ { email: "myemail@ahome.com, role: "A Role" }] }