### PR TITLE
Add timestamp to project data

### DIFF
--- a/db/migrations/12_add_timestamp_to_projects_table.rb
+++ b/db/migrations/12_add_timestamp_to_projects_table.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:projects) do
+      add_column :timestamp, Integer, default: 0
+    end
+  end
+end

--- a/lib/homes_england/domain/project.rb
+++ b/lib/homes_england/domain/project.rb
@@ -1,5 +1,5 @@
 class HomesEngland::Domain::Project
-  attr_accessor :name, :type, :data, :status
+  attr_accessor :name, :type, :data, :status, :timestamp
 
   def initialize
     @status = 'Draft'

--- a/lib/homes_england/gateway/sequel_project.rb
+++ b/lib/homes_england/gateway/sequel_project.rb
@@ -22,6 +22,7 @@ class HomesEngland::Gateway::SequelProject
       p.type = row[:type]
       p.data = Common::DeepSymbolizeKeys.to_symbolized_hash(row[:data].to_h)
       p.status = row[:status]
+      p.timestamp = row[:timestamp]
     end
   end
 
@@ -31,7 +32,8 @@ class HomesEngland::Gateway::SequelProject
               .update(
                 name: project.name,
                 data: Sequel.pg_json(project.data),
-                status: project.status
+                status: project.status,
+                timestamp: project.timestamp
               )
 
     { success: updated.positive? }

--- a/lib/homes_england/use_case/find_project.rb
+++ b/lib/homes_england/use_case/find_project.rb
@@ -9,7 +9,8 @@ class HomesEngland::UseCase::FindProject
       name: project.name,
       type: project.type,
       data: project.data,
-      status: project.status
+      status: project.status,
+      timestamp: project.timestamp
     }
   end
 end

--- a/lib/homes_england/use_case/update_project.rb
+++ b/lib/homes_england/use_case/update_project.rb
@@ -3,13 +3,23 @@ class HomesEngland::UseCase::UpdateProject
     @project_gateway = project_gateway
   end
 
-  def execute(project_id:, project_data:)
+  def execute(project_id:, project_data:, timestamp:)
     current_project = @project_gateway.find_by(id: project_id)
+
+    return { successful: false, errors: [:incorrect_timestamp] } unless valid_timestamps?(current_project.timestamp, timestamp)
+    
     current_project.data = project_data
     current_project.status = 'Draft'
+    current_project.timestamp = Time.now.to_i
 
     successful = @project_gateway.update(id: project_id, project: current_project)[:success]
 
-    { successful: successful }
+    { successful: successful, errors: [] }
+  end
+
+  private
+
+  def valid_timestamps?(saved_timestamp, new_timestamp)
+    saved_timestamp == new_timestamp || saved_timestamp.zero?
   end
 end

--- a/lib/ui/use_case/get_project.rb
+++ b/lib/ui/use_case/get_project.rb
@@ -18,7 +18,8 @@ class UI::UseCase::GetProject
       type: found_project[:type],
       data: found_project[:data],
       status: found_project[:status],
-      schema: template.schema
+      schema: template.schema,
+      timestamp: found_project[:timestamp]
     }
   end
 

--- a/lib/ui/use_case/update_project.rb
+++ b/lib/ui/use_case/update_project.rb
@@ -5,16 +5,17 @@ class UI::UseCase::UpdateProject
     @update_project = update_project
     @convert_ui_hif_project = convert_ui_hif_project
   end
-
-  def execute(id:, data:, type: nil)
+  
+  def execute(id:, data:, timestamp:, type: nil)
     data = convert_data(data) if type == 'hif'
-    
-    successful = @update_project.execute(
+ 
+    response = @update_project.execute(
       project_id: id,
-      project_data: data
-    )[:successful]
+      project_data: data,
+      timestamp: timestamp
+    )
 
-    { successful: successful }
+    { successful: response[:successful], errors: response[:errors] }
   end
 
   private

--- a/spec/acceptance/homes_england/update_project_spec.rb
+++ b/spec/acceptance/homes_england/update_project_spec.rb
@@ -23,7 +23,7 @@ describe 'Updating a HIF Project' do
     }
 
     response = get_use_case(:create_new_project).execute(name: 'cat project', type: 'hif', baseline: project_baseline)
-    success = get_use_case(:update_project).execute(project_id: response[:id], project_data: { cats: 'meow' })
+    success = get_use_case(:update_project).execute(project_id: response[:id], project_data: { cats: 'meow' }, timestamp: 123)
 
     expect(success[:successful]).to eq(true)
 
@@ -55,11 +55,44 @@ describe 'Updating a HIF Project' do
       response = get_use_case(:create_new_project).execute(name: 'cat project', type: 'hif', baseline: project_baseline)
       get_use_case(:submit_project).execute(project_id: response[:id])
 
-      get_use_case(:update_project).execute(project_id: response[:id], project_data: { cats: 'meow' })
+      get_use_case(:update_project).execute(project_id: response[:id], project_data: { cats: 'meow' }, timestamp: 2)
 
       updated_project = get_use_case(:find_project).execute(id: response[:id])
 
       expect(updated_project[:status]).to eq('Draft')
+    end
+  end
+
+  context 'updating an old version of the project data' do
+    it 'wont overwrite the more recent version of the project data' do
+      project_baseline = {
+        summary: {
+          project_name: 'Cats Protection League',
+          description: 'A new headquarters for all the Cats',
+          lead_authority: 'Made Tech'
+        },
+        infrastructure: {
+          type: 'Cat Bathroom',
+          description: 'Bathroom for Cats',
+          completion_date: '2018-12-25'
+        },
+        financial: {
+          date: '2017-12-25',
+          funded_through_HIF: true
+        }
+      }
+
+      project_id = get_use_case(:create_new_project).execute(name: 'cat project', type: 'hif', baseline: project_baseline)[:id]
+
+      get_use_case(:update_project).execute(project_id: project_id, project_data: { cats: 'meow' }, timestamp: Time.now.to_i)
+      updated_project = get_use_case(:find_project).execute(id: project_id)
+
+      expect(updated_project[:timestamp]).to eq(Time.now.to_i)
+
+      response = get_use_case(:update_project).execute(project_id: project_id, project_data: { cats: 'meow' }, timestamp: Time.now.to_i - 2000)
+
+      expect(response).to eq({successful: false, errors: [:incorrect_timestamp]})
+      expect(updated_project[:data]).to eq({ cats: 'meow'})
     end
   end
 end

--- a/spec/acceptance/ui/hif_project_spec.rb
+++ b/spec/acceptance/ui/hif_project_spec.rb
@@ -72,7 +72,7 @@ describe 'Interacting with a HIF Project from the UI' do
     it 'Can update a created project successfully' do
       project_id = create_project
 
-      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: updated_ui_baseline_data, type: 'hif')
+      dependency_factory.get_use_case(:ui_update_project).execute(id: project_id, data: updated_ui_baseline_data, type: 'hif', timestamp: 2)
 
       updated_project = get_project(project_id)
 

--- a/spec/unit/homes_england/gateway/sequel_project_spec.rb
+++ b/spec/unit/homes_england/gateway/sequel_project_spec.rb
@@ -43,6 +43,7 @@ describe HomesEngland::Gateway::SequelProject do
         project.name = 'Dog project'
         project.data = { dogs: 'woof' }
         project.status = 'Draft'
+        project.timestamp = 56789123
         project_gateway.update(id: project_id, project: project)
 
         created_project = project_gateway.find_by(id: project_id)
@@ -51,6 +52,7 @@ describe HomesEngland::Gateway::SequelProject do
         expect(created_project.type).to eq('Animals')
         expect(created_project.data).to eq(dogs: 'woof')
         expect(created_project.status).to eq('Draft')
+        expect(created_project.timestamp).to eq(56789123)
       end
 
       it 'returns successful' do
@@ -114,6 +116,7 @@ describe HomesEngland::Gateway::SequelProject do
 
       it 'updates the project' do
         project.data[:barn] << { chicken: 'cluck' }
+        project.timestamp = 78912
 
         project_gateway.update(id: project_id, project: project)
 
@@ -127,6 +130,7 @@ describe HomesEngland::Gateway::SequelProject do
           ],
           barn: [{ chicken: 'cluck' }]
         )
+        expect(created_project.timestamp).to eq(78912)
       end
 
       it 'returns successful' do

--- a/spec/unit/homes_england/use_case/find_project_spec.rb
+++ b/spec/unit/homes_england/use_case/find_project_spec.rb
@@ -16,6 +16,7 @@ describe HomesEngland::UseCase::FindProject do
         p.type = 'hif'
         p.data = { dogs: 'woof' }
         p.status = 'Draft'
+        p.timestamp = 0
       end
     end
     let(:id) { 1 }
@@ -39,6 +40,10 @@ describe HomesEngland::UseCase::FindProject do
     it 'returns a hash containing the projects status' do
       expect(response[:status]).to eq('Draft')
     end
+
+    it 'returns a hash containing the projects timestamp' do
+      expect(response[:timestamp]).to eq(0)
+    end
   end
 
   context 'example two' do
@@ -48,6 +53,7 @@ describe HomesEngland::UseCase::FindProject do
         p.type = 'abc'
         p.data = { cats: 'meow' }
         p.status = 'Submitted'
+        p.timestamp = 456
       end
     end
     let(:id) { 5 }
@@ -70,6 +76,10 @@ describe HomesEngland::UseCase::FindProject do
 
     it 'returns a hash containing the projects status' do
       expect(response[:status]).to eq('Submitted')
+    end
+
+    it 'returns a hash containing the projects timestamp' do
+      expect(response[:timestamp]).to eq(456)
     end
   end
 end

--- a/spec/unit/homes_england/use_case/update_project_spec.rb
+++ b/spec/unit/homes_england/use_case/update_project_spec.rb
@@ -3,94 +3,192 @@
 require 'rspec'
 
 describe HomesEngland::UseCase::UpdateProject do
-  let(:use_case) { described_class.new(project_gateway: project_gateway_spy) }
-  let(:response) { use_case.execute(project_id: project_id, project_data: updated_project_data) }
-  let(:la_project) { HomesEngland::Domain::Project.new }
+  context 'first update' do 
+    let(:use_case) { described_class.new(project_gateway: project_gateway_spy) }
+    let(:response) do
+      use_case.execute(
+        project_id: project_id,
+        project_data: updated_project_data,
+        timestamp: timestamp
+      )
+    end
+    let(:la_project) { HomesEngland::Domain::Project.new }
+  
+    before do
+      response
+    end
+  
+  
+    context 'example one' do
+      let(:project_id) { 42 }
 
-  before do
-    response
-  end
-
-
-  context 'example one' do
-    let(:project_id) { 42 }
-    let(:updated_project_data) { { ducks: 'quack' } }
-
-    context 'given a successful update whilst in Draft status' do
-      let(:la_project) do
-        HomesEngland::Domain::Project.new.tap do |p|
-          p.status = 'Draft'
-          p.data = { a: 'b' }
+      let(:updated_project_data) { { ducks: 'quack' } }
+  
+      context 'given a successful update whilst in Draft status' do
+        let(:timestamp) { 0 }
+        let(:la_project) do
+          HomesEngland::Domain::Project.new.tap do |p|
+            p.status = 'Draft'
+            p.data = { a: 'b' }
+            p.timestamp = 0
+          end
+        end
+  
+        let(:project_gateway_spy) do
+          spy(find_by: la_project, update: { success: true })
+        end
+  
+        it 'Should pass the ID to the gateway' do
+          expect(project_gateway_spy).to have_received(:update).with(
+            hash_including(id: 42)
+          )
+        end
+  
+        it 'Should pass the project to the gateway' do
+          expect(project_gateway_spy).to have_received(:update) do |request|
+            project = request[:project]
+            expect(project.data).to eq(ducks: 'quack')
+          end
+        end
+  
+        it 'Should return successful' do
+          expect(response).to eq(successful: true, errors:[])
+        end
+  
+        it 'Should pass Draft status to the gateway' do
+          expect(project_gateway_spy).to have_received(:update) do |request|
+            project = request[:project]
+            expect(project.status).to eq('Draft')
+          end
         end
       end
 
-      let(:project_gateway_spy) do
-        spy(find_by: la_project, update: { success: true })
-      end
+      context 'given an incorrect timestamp' do
+        let(:timestamp) { 0 }
 
-      it 'Should pass the ID to the gateway' do
-        expect(project_gateway_spy).to have_received(:update).with(
-          hash_including(id: 42)
-        )
-      end
+        let(:la_project) do
+          HomesEngland::Domain::Project.new.tap do |p|
+            p.status = 'Draft'
+            p.data = { a: 'b' }
+            p.timestamp = 5
+          end
+        end
+  
+        let(:project_gateway_spy) do
+          spy(find_by: la_project, update: { success: true })
+        end
 
-      it 'Should pass the project to the gateway' do
-        expect(project_gateway_spy).to have_received(:update) do |request|
-          project = request[:project]
-          expect(project.data).to eq(ducks: 'quack')
+        it 'pass the data to the gateway' do 
+          expect(project_gateway_spy).not_to have_received(:update)
+        end
+
+        it 'returns unsuccessful' do
+          expect(response[:successful]).to eq(false)
+        end
+
+        it 'returns an incorrect timestamp error' do
+          expect(response[:errors]).to eq([:incorrect_timestamp])
+        end
+      end
+    end
+    
+    context 'example two' do
+      let(:project_id) { 123 }
+      let(:updated_project_data) { { cows: 'moo' } }
+      
+      context 'given a successful update whilst in Draft status' do
+        let(:timestamp) { 0 }
+        let(:la_project) do
+          HomesEngland::Domain::Project.new.tap do |p|
+            p.status = 'Draft'
+            p.data = { b: 'c' }
+            p.timestamp = 0
+          end
+        end
+        let(:project_gateway_spy) do
+          spy(find_by: la_project, update: { success: true })
+        end
+  
+        it 'Should pass the ID to the gateway' do
+          expect(project_gateway_spy).to have_received(:update).with(
+            hash_including(id: 123)
+          )
+        end
+  
+        it 'Should pass the project to the gateway' do
+          expect(project_gateway_spy).to have_received(:update) do |request|
+            project = request[:project]
+            expect(project.data).to eq(cows: 'moo')
+          end
+        end
+  
+        it 'Should return successful' do
+          expect(response).to eq(successful: true, errors:[])
+        end
+  
+        it 'Should pass Draft status to the gateway' do
+          expect(project_gateway_spy).to have_received(:update) do |request|
+            project = request[:project]
+            expect(project.status).to eq('Draft')
+          end
         end
       end
 
-      it 'Should return successful' do
-        expect(response).to eq(successful: true)
-      end
+      context 'given an incorrect timestamp' do
+        let(:timestamp) { 4 }
 
-      it 'Should pass Draft status to the gateway' do
-        expect(project_gateway_spy).to have_received(:update) do |request|
-          project = request[:project]
-          expect(project.status).to eq('Draft')
+        let(:la_project) do
+          HomesEngland::Domain::Project.new.tap do |p|
+            p.status = 'Draft'
+            p.data = { c: 'd' }
+            p.timestamp = 9
+          end
+        end
+  
+        let(:project_gateway_spy) do
+          spy(find_by: la_project, update: { success: true })
+        end
+
+        it 'pass the data to the gateway' do 
+          expect(project_gateway_spy).not_to have_received(:update)
+        end
+
+        it 'returns unsuccessful' do
+          expect(response[:successful]).to eq(false)
+        end
+
+        it 'returns an incorrect timestamp error' do
+          expect(response[:errors]).to eq([:incorrect_timestamp])
         end
       end
     end
   end
 
-  context 'example two' do
-    let(:project_id) { 123 }
-    let(:updated_project_data) { { cows: 'moo' } }
+  context 'second update' do
+    it 'Increases the timestamp' do
+      time_now = Time.now.to_i
 
-    context 'given a successful update whilst in Draft status' do
-      let(:la_project) do
-        HomesEngland::Domain::Project.new.tap do |p|
+      current_project = HomesEngland::Domain::Project.new.tap do |p|
           p.status = 'Draft'
-          p.data = { b: 'c' }
+          p.data = { a: 'b' }
+          p.timestamp = time_now
         end
-      end
-      let(:project_gateway_spy) do
-        spy(find_by: la_project, update: { success: true })
-      end
+  
+      project_gateway_spy = spy(find_by: current_project, update: { success: true })
+      
+      use_case = described_class.new(project_gateway: project_gateway_spy)
 
-      it 'Should pass the ID to the gateway' do
-        expect(project_gateway_spy).to have_received(:update).with(
-          hash_including(id: 123)
-        )
-      end
+      sleep(1)
 
-      it 'Should pass the project to the gateway' do
-        expect(project_gateway_spy).to have_received(:update) do |request|
-          project = request[:project]
-          expect(project.data).to eq(cows: 'moo')
-        end
-      end
-
-      it 'Should return successful' do
-        expect(response).to eq(successful: true)
-      end
-
-      it 'Should pass Draft status to the gateway' do
-        expect(project_gateway_spy).to have_received(:update) do |request|
-          project = request[:project]
-          expect(project.status).to eq('Draft')
-        end
+      response = use_case.execute(
+        project_id: 4,
+        project_data: { ducks: 'Quack'},
+        timestamp: time_now
+      )
+  
+      expect(project_gateway_spy).to have_received(:update) do |request|
+        project = request[:project]
+        expect(project.timestamp).to be > time_now
       end
     end
   end

--- a/spec/unit/ui/use_case/get_project_spec.rb
+++ b/spec/unit/ui/use_case/get_project_spec.rb
@@ -16,7 +16,8 @@ describe UI::UseCase::GetProject do
           name: 'Big Buildings',
           type: 'hif',
           data: { building1: 'a house' },
-          status: 'Draft'
+          status: 'Draft',
+          timestamp: 0
         }
       )
     end
@@ -62,6 +63,10 @@ describe UI::UseCase::GetProject do
 
     it 'Return the status from find project' do
       expect(response[:status]).to eq('Draft')
+    end
+
+    it 'Returns the timestamp from find project' do
+      expect(response[:timestamp]).to eq(0)
     end
 
     context 'Given a hif project' do
@@ -119,7 +124,8 @@ describe UI::UseCase::GetProject do
           name: 'Big ol woof',
           type: 'hif',
           data: { noise: 'bark' },
-          status: 'Barking'
+          status: 'Barking',
+          timestamp: 345
         }
       )
     end
@@ -165,6 +171,10 @@ describe UI::UseCase::GetProject do
 
     it 'Return the status from find project' do
       expect(response[:status]).to eq('Barking')
+    end
+
+    it 'Return the timestamp from find project' do
+      expect(response[:timestamp]).to eq(345)
     end
 
     context 'Given a hif project' do

--- a/spec/unit/ui/use_case/update_project_spec.rb
+++ b/spec/unit/ui/use_case/update_project_spec.rb
@@ -2,7 +2,7 @@
 
 describe UI::UseCase::UpdateProject do
   context 'Example one' do
-    let(:update_project_spy) { spy(execute: { successful: true }) }
+    let(:update_project_spy) { spy(execute: { successful: true, errors: [] }) }
     let(:convert_ui_hif_project_spy) { spy(execute: { catto: 'meow' }) }
     let(:use_case) do
       described_class.new(
@@ -11,7 +11,7 @@ describe UI::UseCase::UpdateProject do
       )
     end
     let(:response) do
-      use_case.execute(id: 7, type: 'hif', data: { cat: 'meow' })
+      use_case.execute(id: 7, type: 'hif', data: { cat: 'meow' }, timestamp: 5)
     end
 
     before { response }
@@ -27,7 +27,19 @@ describe UI::UseCase::UpdateProject do
     end
 
     it 'Returns successful if successful' do
-      expect(response).to eq(successful: true)
+      expect(response[:successful]).to eq(true)
+    end
+
+    it 'Returns the errors array' do
+      expect(response[:errors]).to eq([])
+    end
+
+    it 'Passes the update project use case the timestamp' do
+      expect(update_project_spy).to have_received(:execute).with(
+        hash_including(
+          timestamp: 5
+        )
+      )
     end
 
     context 'Given a hif project' do
@@ -54,7 +66,7 @@ describe UI::UseCase::UpdateProject do
 
     context 'Given a non-hif project' do
       let(:response) do
-        use_case.execute(id: 7, type: 'ac', data: { cat: 'meow' })
+        use_case.execute(id: 7, type: 'ac', data: { cat: 'meow' }, timestamp: 6)
       end
 
       it 'Does not call execute on the convert usecase' do
@@ -74,7 +86,7 @@ describe UI::UseCase::UpdateProject do
   end
 
   context 'Example two' do
-    let(:update_project_spy) { spy(execute: { successful: false }) }
+    let(:update_project_spy) { spy(execute: { successful: false, errors: [:incorrect_timestamp] }) }
     let(:convert_ui_hif_project_spy) { spy(execute: { doggo: 'woof' }) }
     let(:use_case) do
       described_class.new(
@@ -82,7 +94,7 @@ describe UI::UseCase::UpdateProject do
         convert_ui_hif_project: convert_ui_hif_project_spy
       )
     end
-    let(:response) { use_case.execute(id: 2, type: 'hif', data: { dog: 'woof' }) }
+    let(:response) { use_case.execute(id: 2, type: 'hif', data: { dog: 'woof' }, timestamp: 8) }
 
     before { response }
 
@@ -97,7 +109,19 @@ describe UI::UseCase::UpdateProject do
     end
 
     it 'Returns unsuccessful if unsuccessful' do
-      expect(response).to eq(successful: false)
+      expect(response[:successful]).to eq(false)
+    end
+
+    it 'Returns the errors array' do
+      expect(response[:errors]).to eq([:incorrect_timestamp])
+    end
+    
+    it 'Passes the update project use case the timestamp' do
+      expect(update_project_spy).to have_received(:execute).with(
+        hash_including(
+          timestamp: 8
+        )
+      )
     end
 
     context 'Given a hif project' do
@@ -124,7 +148,7 @@ describe UI::UseCase::UpdateProject do
 
     context 'Given a non-hif project' do
       let(:response) do
-        use_case.execute(id: 7, type: 'ac', data: { dog: 'woof' })
+        use_case.execute(id: 7, type: 'ac', data: { dog: 'woof' }, timestamp: 6)
       end
 
       it 'Does not call execute on the convert usecase' do

--- a/spec/web_routes/update_project_spec.rb
+++ b/spec/web_routes/update_project_spec.rb
@@ -5,7 +5,7 @@ require_relative 'delivery_mechanism_spec_helper'
 
 describe 'Updating a project' do
   let(:get_project_spy) { spy(execute: { type: 'hif' })}
-  let(:update_project_spy) { spy(execute: { successful: true }) }
+  let(:update_project_spy) { spy(execute: { successful: true, errors: [] }) }
   let(:create_new_project_spy) { spy(execute: project_id) }
   let(:project_id) { 1 }
 
@@ -67,6 +67,19 @@ describe 'Updating a project' do
         end
       end
     end
+
+    context 'timestamp' do
+      let(:update_project_spy) { spy(execute: { successful: true, errors: :incorrect_timestamp }) }
+      it 'should return error message and 200' do
+        post '/project/update', { project_id: project_id, project_data: {data: 'some'}, timestamp: '1'}.to_json
+        response = Common::DeepSymbolizeKeys.to_symbolized_hash(
+          JSON.parse(last_response.body)
+        )
+
+        expect(last_response.status).to eq(200)
+        expect(response).to eq(errors: "incorrect_timestamp")
+      end
+    end
   end
 
   context 'with valid id and project' do
@@ -74,7 +87,8 @@ describe 'Updating a project' do
       post '/project/update', {
         project_id: project_id,
         project_type: 'hif',
-        project_data: new_project_data[:baselineData]
+        project_data: new_project_data[:baselineData],
+        timestamp: '67'
       }.to_json
     end
 
@@ -93,7 +107,8 @@ describe 'Updating a project' do
         have_received(:execute).with(
           id: project_id,
           type: 'hif',
-          data: { cats: 'quack', dogs: 'baa' }
+          data: { cats: 'quack', dogs: 'baa' },
+          timestamp: 67
         )
       )
     end


### PR DESCRIPTION
 - Adds a timestamp to the projects table
 - It will send this timestamp out in find project
 - When the frontend sends an update request, it includes the timestamp in the data; it checks the timestamp in the database against this timestamp.
 - If the timestamps are different it won't save the data and will return an error. 

This is to stop a later update request, using out of date data, from overwriting a more recent copy of the data.

This is to stop two people who have the project open saving one after the other and the second one saving overwriting the first ones save. 