### PR TITLE
Add CircleCI config ready for GovPaaS migration

### DIFF
--- a/.circleci/config.govpaas.yml
+++ b/.circleci/config.govpaas.yml
@@ -1,0 +1,120 @@
+version: 2.1
+
+executors:
+  ruby:
+    docker:
+      - image: circleci/ruby:2.5.1
+      - image: circleci/postgres:9.4.18-alpine
+        environment:
+          POSTGRES_USER: circleci
+          POSTGRES_PASSWORD: super-secret
+          POSTGRES_DB: monitor_api
+
+    working_directory: ~/repo
+
+    environment:
+      DATABASE_URL: 'postgres://circleci:super-secret@localhost/monitor_api'
+      NO_LOGS: 'true'
+
+jobs:
+  build_and_test:
+    executor: ruby
+
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+          - v1-dependencies-{{ checksum "Gemfile.lock" }}
+          - v1-dependencies-
+      - run:
+          name: install dependencies
+          command: |
+            sudo apt-get install postgresql-client
+            bundle install --jobs=4 --retry=3 --path vendor/bundle
+      - save_cache:
+          paths:
+            - ./vendor/bundle
+          key: v1-dependencies-{{ checksum "Gemfile.lock" }}
+      - run:
+          name: Waiting for Postgres to be ready
+          command: |
+            while ! psql $DATABASE_URL -c 'SELECT 1'; do
+                echo 'Waiting for db'; sleep 3;
+            done
+      - run:
+          name: run tests
+          command: |
+            mkdir /tmp/test-results
+            TEST_FILES="$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)"
+
+            bundle exec rspec --format progress \
+                            --format RspecJunitFormatter \
+                            --out /tmp/test-results/rspec.xml \
+                            --format progress \
+                            $TEST_FILES
+      - store_test_results:
+          path: /tmp/test-results
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: test-results
+      - store_artifacts:
+          path: coverage
+          destination: coverage
+
+  deploy_staging:
+    executor: ruby
+    steps:
+      - checkout
+      - run: scripts/deploy.sh staging
+
+  deploy_dark_production:
+    executor: ruby
+    steps:
+      - checkout
+      - run: scripts/deploy.sh production
+
+  flip_production:
+    executor: ruby
+    steps:
+      - checkout
+      - run: scripts/flip-dark-to-live.sh production
+
+  revert_production:
+    executor: ruby
+    steps:
+      - checkout
+      - run: scripts/flip-dark-to-live.sh production
+
+workflows:
+  version: 2
+  build_test_deploy:
+    jobs:
+      - build_and_test
+      - deploy_staging:
+          requires:
+            - build_and_test
+          filters:
+            branches:
+              only:
+                - master
+      - hold_production_deploy:
+          type: approval
+          requires:
+            - deploy_staging
+      - deploy_dark_production:
+          requires:
+            - hold_production_deploy
+      - hold_flip_production:
+          type: approval
+          requires:
+            - deploy_dark_production
+      - flip_production:
+          requires:
+            - hold_flip_production
+      - hold_revert_production:
+          type: approval
+          requires:
+            - flip_production
+      - revert_production:
+          requires:
+            - hold_revert_production

--- a/deploy-manifests/production-dark.yml
+++ b/deploy-manifests/production-dark.yml
@@ -1,0 +1,4 @@
+---
+applications:
+- name: monitor-api-production-dark
+  #memory: 512M

--- a/deploy-manifests/staging.yml
+++ b/deploy-manifests/staging.yml
@@ -1,0 +1,6 @@
+---
+applications:
+- name: monitor-api-staging
+  #memory: 512M
+  #services:
+  #- monitor-staging-db

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo 'Provide an environment to deploy'
+  exit 1
+fi
+
+ENVIRONMENT_NAME="$1"
+APP_NAME="$1"
+
+if [ "${ENVIRONMENT_NAME}" == "production" ]; then
+  APP_NAME="${APP_NAME}-dark"
+fi
+
+curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
+./cf api https://api.cloud.service.gov.uk
+./cf auth "${CF_USER}" "${CF_PASSWORD}"
+
+./cf target -o "${CF_ORG}" -s "${ENVIRONMENT_NAME}"
+
+./cf push -f "deploy-manifests/${APP_NAME}.yml"
+./cf set-env "monitor-api-${APP_NAME}" circle_commit "${CIRCLE_SHA1}"
+./cf set-env "monitor-api-${APP_NAME}" SENTRY_DSN "${SENTRY_DSN}"

--- a/scripts/flip-dark-to-live.sh
+++ b/scripts/flip-dark-to-live.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [ -z "$1" ]; then
+  echo 'Provide an environment to deploy'
+  exit 1
+fi
+
+ENVIRONMENT_NAME="$1"
+SPACE_NAME="${ENVIRONMENT_NAME}"
+APP_NAME="monitor-api-${ENVIRONMENT_NAME}"
+APP_HOSTNAME="monitor-api-${ENVIRONMENT_NAME}"
+DARK_APP_NAME="${APP_NAME}-dark"
+DARK_APP_HOSTNAME="${APP_NAME}-dark"
+
+curl -L "https://packages.cloudfoundry.org/stable?release=linux64-binary&source=github" | tar -zx
+./cf api https://api.cloud.service.gov.uk
+./cf auth "${CF_USER}" "${CF_PASSWORD}"
+
+./cf target -o "${CF_ORG}" -s "${SPACE_NAME}"
+
+./cf map-route "${DARK_APP_NAME}" "${CF_DOMAIN}" -n "${APP_HOSTNAME}"
+./cf unmap-route "${APP_NAME}" "${CF_DOMAIN}" -n "${APP_HOSTNAME}"
+
+./cf map-route "${APP_NAME}" "${CF_DOMAIN}" -n "${DARK_APP_HOSTNAME}"
+./cf unmap-route "${APP_NAME}-dark" "${CF_DOMAIN}" -n "${DARK_APP_HOSTNAME}"
+
+./cf rename "${APP_NAME}" "${APP_NAME}-temp"
+./cf rename "${APP_NAME}-dark" "${APP_NAME}"
+./cf rename "${APP_NAME}-temp" "${APP_NAME}-dark"


### PR DESCRIPTION
The config for CircleCI is located in `.circleci/config.govpaas.yml` and can we swapped out when ready to migrate across. This will not interfere with the current CircleCI configuration.

It's tricky to test currently as we don't have a paid account for GovPaaS, so some tweaking might be required when ready to migrate, such as memory of instances. Secrets will also need adding to CircleCI when ready, and finally the DB migrated from Heroku.