### PR TITLE
Extend source key so that baseline data can be chosen if there is no return data present.

### DIFF
--- a/lib/local_authority/gateway/hif_returns_schema.rb
+++ b/lib/local_authority/gateway/hif_returns_schema.rb
@@ -1283,7 +1283,7 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
                     period: {
                       title: 'Period',
                       type: 'string',
-                      sourceKey: %i[baseline_data fundingProfiles period],
+                      sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :period],[:return_data, :fundingProfiles, :currentFunding, :forecast, :period]],
                       readonly: true
                     },
                     forecast: {
@@ -1294,37 +1294,89 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
                         instalment1: {
                           title: '1st Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment1],
+                          sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :instalment1],[:return_data, :fundingProfiles, :currentFunding, :forecast, :instalment1]],
                           readonly: true,
                           currency: true
                         },
                         instalment2: {
                           title: '2nd Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment2],
+                          sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :instalment2],[:return_data, :fundingProfiles, :currentFunding, :forecast, :instalment2]],
                           readonly: true,
                           currency: true
                         },
                         instalment3: {
                           title: '3rd Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment3],
+                          sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :instalment3], [:return_data, :fundingProfiles, :currentFunding, :forecast, :instalment3]],
                           readonly: true,
                           currency: true
                         },
                         instalment4: {
                           title: '4th Quarter',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles instalment4],
+                          sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :instalment4],[:return_data, :fundingProfiles, :currentFunding, :forecast, :instalment4]],
                           readonly: true,
                           currency: true
                         },
                         total: {
                           title: 'Total',
                           type: 'string',
-                          sourceKey: %i[baseline_data fundingProfiles total],
+                          sourceKey: [:return_or_baseline, [:baseline_data, :fundingProfiles, :total],[:return_data, :fundingProfiles, :currentFunding, :forecast, :total]],
                           readonly: true,
                           currency: true
+                        }
+                      }
+                    }
+                  }
+                }
+              },
+              currentFunding: {
+                type: "object",
+                title: " ",
+                properties: {
+                  forecast: {
+                  title: " ",
+                  type: "array",
+                  quarterly: true,
+                    items: {
+                      type: "object",
+                      properties: {
+                        period: {
+                          title: "Period",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest period],
+                          hidden: true
+                        },
+                        instalment1: {
+                          title: "1st Quarter",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest forecast instalment1],
+                          hidden: true
+                        },
+                        instalment2: {
+                          title: "2nd Quarter",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest forecast instalment2],
+                          hidden: true
+                        },
+                        instalment3: {
+                          title: "3rd Quarter",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest forecast instalment3],
+                          hidden: true
+                        },
+                        instalment4: {
+                          title: "4th Quarter",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest forecast instalment4],
+                          hidden: true
+                        },
+                        total: {
+                          title: "Total",
+                          type: "string",
+                          sourceKey: %i[return_data fundingProfiles fundingRequest forecast total],
+                          hidden: true
                         }
                       }
                     }

--- a/lib/local_authority/use_case/find_path_data.rb
+++ b/lib/local_authority/use_case/find_path_data.rb
@@ -1,5 +1,8 @@
 class LocalAuthority::UseCase::FindPathData
   def execute(baseline_data:, path:)
+
+    path = choose_path(baseline_data, path) if path[0] == :return_or_baseline 
+
     found = search_hash(baseline_data, path)
     if !(found.nil? || found.empty?)
       { found: found }
@@ -9,6 +12,14 @@ class LocalAuthority::UseCase::FindPathData
   end
 
   private
+
+  def choose_path(baseline_data, path)
+    if baseline_data[:return_data].empty?
+      path[1]
+    else
+      path[2]
+    end
+  end
 
   def search_array(baseline_data, path)
     baseline_data.map do |x|

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -1454,6 +1454,7 @@
     "fundingProfiles": {
       "type": "object",
       "title": "HIF Grant Expenditure",
+      "calculation": "get(formData, 'changeRequired') === 'Change required' ? set(formData['currentFunding'], 'forecast', get(formData, 'requestedProfiles', 'newProfile')) : set(formData['currentFunding'], 'forecast', get(formData, 'fundingRequest', 'forecast'))",
       "properties": {
         "totalHIFGrant": {
           "type": "string",
@@ -1541,6 +1542,51 @@
           "description": "Please confirm there are no changes to be made to the funding profile",
           "radio": true,
           "enum": ["Confirmed", "Change required"]
+        },
+        "currentFunding": {
+          "type": "object",
+          "title": "",
+          "properties": {
+            "forecast": {
+            "title": "",
+            "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {
+                  "period": {
+                    "title": "Period",
+                    "type": "string",
+                    "hidden": true              
+                  },
+                  "instalment1": {
+                    "title": "1st Quarter",
+                    "type": "string",
+                    "hidden": true
+                  },
+                  "instalment2": {
+                    "title": "2nd Quarter",
+                    "type": "string",
+                    "hidden": true
+                  },
+                  "instalment3": {
+                    "title": "3rd Quarter",
+                    "type": "string",
+                    "hidden": true
+                  },
+                  "instalment4": {
+                    "title": "4th Quarter",
+                    "type": "string",
+                    "hidden": true
+                  },
+                  "total": {
+                    "title": "Total",
+                    "type": "string",
+                    "hidden": true
+                  }
+                }
+              }
+            }
+          }
         }
       },
       "dependencies": {
@@ -1561,6 +1607,7 @@
                 "requestedProfiles": {
                   "type": "object",
                   "title": "Funding Request",
+                  "calculation": "periodTotal(formData, 'total', 'newProfile', 'instalment1', 'instalment2', 'instalment3', 'instalment4'); ",
                   "properties": {
                     "newProfile": {
                     "title": "New Profile",

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -1463,22 +1463,22 @@
           "sourceKey": ["baseline_data", "summary", "hifFundingAmount"]
         },
         "fundingRequest": {
-          "type": "array",
+          "type": "object",
           "title": "Funding Request",
-          "items": {
-            "type": "object",
-            "properties": {
-              "period": {
-                "title": "Period",
-                "type": "string",
-                "sourceKey": ["baseline_data", "fundingProfiles", "period"],
-                "readonly": true
-              },
-              "forecast": {
-                "title": "Forecast",
+          "properties": {
+            "forecast": {
+            "title": "Forecast",
+            "type": "array",
+            "quarterly": true,
+              "items": {
                 "type": "object",
-                "horizontal": true,
                 "properties": {
+                  "period": {
+                    "title": "Period",
+                    "type": "string",
+                    "sourceKey": ["baseline_data", "fundingProfiles", "period"],
+                    "readonly": true
+                  },
                   "instalment1": {
                     "title": "1st Quarter",
                     "type": "string",
@@ -1559,26 +1559,26 @@
                   "title": "Mitigation in place to reduce further slippage"
                 },
                 "requestedProfiles": {
-                  "type": "array",
+                  "type": "object",
                   "title": "Funding Request",
-                  "items": {
-                    "type": "object",
-                    "properties": {
-                      "period": {
-                        "title": "Period",
-                        "type": "string",
-                        "sourceKey": [
-                          "baseline_data",
-                          "fundingProfiles",
-                          "period"
-                        ],
-                        "readonly": true
-                      },
-                      "newProfile": {
-                        "title": "New Profile",
+                  "properties": {
+                    "newProfile": {
+                    "title": "New Profile",
+                    "quarterly": true,
+                    "type": "array",
+                      "items": {
                         "type": "object",
-                        "horizontal": true,
                         "properties": {
+                          "period": {
+                            "title": "Period",
+                            "type": "string",
+                            "sourceKey": [
+                              "baseline_data",
+                              "fundingProfiles",
+                              "period"
+                            ],
+                            "readonly": true
+                          },
                           "instalment1": {
                             "title": "1st Quarter",
                             "type": "string",
@@ -1602,7 +1602,8 @@
                           "total": {
                             "title": "Total",
                             "type": "string",
-                            "currency": true
+                            "currency": true,
+                            "readonly": true
                           }
                         }
                       }

--- a/lib/ui/use_case/convert_core_hif_return.rb
+++ b/lib/ui/use_case/convert_core_hif_return.rb
@@ -267,38 +267,42 @@ class UI::UseCase::ConvertCoreHIFReturn
     @converted_return[:fundingProfiles] = {}
     @converted_return[:fundingProfiles][:totalHIFGrant] = @return[:fundingProfiles][:totalHIFGrant]
 
-    @converted_return[:fundingProfiles][:fundingRequest] = @return[:fundingProfiles][:fundingRequest].map do |request|
+    @converted_return[:fundingProfiles][:fundingRequest] = {}
+
+    @converted_return[:fundingProfiles][:fundingRequest][:forecast] = @return[:fundingProfiles][:fundingRequest].map do |request|
       next if request.nil?
 
       new_request = { period: request[:period] }
-
+      
       next new_request if request[:forecast].nil?
-      new_request[:forecast] = {
-        instalment1: request[:forecast][:instalment1],
-        instalment2: request[:forecast][:instalment2],
-        instalment3: request[:forecast][:instalment3],
-        instalment4: request[:forecast][:instalment4],
-        total: request[:forecast][:total]
-      }
+
+      new_request[:instalment1] = request[:forecast][:instalment1],
+      new_request[:instalment2] = request[:forecast][:instalment2],
+      new_request[:instalment3] = request[:forecast][:instalment3],
+      new_request[:instalment4] = request[:forecast][:instalment4],
+      new_request[:total] = request[:forecast][:total]
+
       new_request
     end
     @converted_return[:fundingProfiles][:changeRequired] = @return[:fundingProfiles][:changeRequired]
     @converted_return[:fundingProfiles][:reasonForRequest] = @return[:fundingProfiles][:reasonForRequest]
     @converted_return[:fundingProfiles][:mitigationInPlace] = @return[:fundingProfiles][:mitigationInPlace]
 
-    @converted_return[:fundingProfiles][:requestedProfiles] = @return[:fundingProfiles][:requestedProfiles].map do |request|
+    @converted_return[:fundingProfiles][:requestedProfiles] = {}
+
+    @converted_return[:fundingProfiles][:requestedProfiles][:newProfile] = @return[:fundingProfiles][:requestedProfiles].map do |request|
       next if request.nil?
 
       new_request = { period: request[:period] }
 
       next new_request if request[:newProfile].nil?
-      new_request[:newProfile] = {
-        instalment1: request[:newProfile][:instalment1],
-        instalment2: request[:newProfile][:instalment2],
-        instalment3: request[:newProfile][:instalment3],
-        instalment4: request[:newProfile][:instalment4],
-        total: request[:newProfile][:total]
-      }
+
+      new_request[:instalment1] = request[:newProfile][:instalment1],
+      new_request[:instalment2] = request[:newProfile][:instalment2],
+      new_request[:instalment3] = request[:newProfile][:instalment3],
+      new_request[:instalment4] = request[:newProfile][:instalment4],
+      new_request[:total] = request[:newProfile][:total]
+      
       new_request
     end
   end

--- a/lib/ui/use_case/convert_core_hif_return.rb
+++ b/lib/ui/use_case/convert_core_hif_return.rb
@@ -271,19 +271,36 @@ class UI::UseCase::ConvertCoreHIFReturn
 
     @converted_return[:fundingProfiles][:fundingRequest][:forecast] = @return[:fundingProfiles][:fundingRequest].map do |request|
       next if request.nil?
-
       new_request = { period: request[:period] }
       
       next new_request if request[:forecast].nil?
-
-      new_request[:instalment1] = request[:forecast][:instalment1],
-      new_request[:instalment2] = request[:forecast][:instalment2],
-      new_request[:instalment3] = request[:forecast][:instalment3],
-      new_request[:instalment4] = request[:forecast][:instalment4],
+      
+      new_request[:instalment1] = request[:forecast][:instalment1]
+      new_request[:instalment2] = request[:forecast][:instalment2]
+      new_request[:instalment3] = request[:forecast][:instalment3]
+      new_request[:instalment4] = request[:forecast][:instalment4]
       new_request[:total] = request[:forecast][:total]
-
+      
       new_request
     end
+
+    @converted_return[:fundingProfiles][:currentFunding] = {}
+
+    unless @return[:fundingProfiles][:currentFunding].nil?
+      @converted_return[:fundingProfiles][:currentFunding][:forecast] = @return[:fundingProfiles][:currentFunding][:forecast].map do |request|
+        next if request.nil?
+        {
+          period: request[:period],
+          instalment1: request[:instalment1],
+          instalment2: request[:instalment2],
+          instalment3: request[:instalment3],
+          instalment4: request[:instalment4],
+          total: request[:total]
+        }
+      end
+    end
+
+    
     @converted_return[:fundingProfiles][:changeRequired] = @return[:fundingProfiles][:changeRequired]
     @converted_return[:fundingProfiles][:reasonForRequest] = @return[:fundingProfiles][:reasonForRequest]
     @converted_return[:fundingProfiles][:mitigationInPlace] = @return[:fundingProfiles][:mitigationInPlace]
@@ -297,10 +314,10 @@ class UI::UseCase::ConvertCoreHIFReturn
 
       next new_request if request[:newProfile].nil?
 
-      new_request[:instalment1] = request[:newProfile][:instalment1],
-      new_request[:instalment2] = request[:newProfile][:instalment2],
-      new_request[:instalment3] = request[:newProfile][:instalment3],
-      new_request[:instalment4] = request[:newProfile][:instalment4],
+      new_request[:instalment1] = request[:newProfile][:instalment1]
+      new_request[:instalment2] = request[:newProfile][:instalment2]
+      new_request[:instalment3] = request[:newProfile][:instalment3]
+      new_request[:instalment4] = request[:newProfile][:instalment4]
       new_request[:total] = request[:newProfile][:total]
       
       new_request

--- a/lib/ui/use_case/convert_ui_hif_return.rb
+++ b/lib/ui/use_case/convert_ui_hif_return.rb
@@ -267,18 +267,18 @@ class UI::UseCase::ConvertUIHIFReturn
     @converted_return[:fundingProfiles] = {}
     @converted_return[:fundingProfiles][:totalHIFGrant] = @return[:fundingProfiles][:totalHIFGrant]
 
-    @converted_return[:fundingProfiles][:fundingRequest] = @return[:fundingProfiles][:fundingRequest].map do |request|
+    @converted_return[:fundingProfiles][:fundingRequest] = @return[:fundingProfiles][:fundingRequest][:forecast].map do |request|
       next if request.nil?
 
       new_request = { period: request[:period] }
 
-      next new_request if request[:forecast].nil?
+      next new_request if request.nil?
       new_request[:forecast] = {
-        instalment1: request[:forecast][:instalment1],
-        instalment2: request[:forecast][:instalment2],
-        instalment3: request[:forecast][:instalment3],
-        instalment4: request[:forecast][:instalment4],
-        total: request[:forecast][:total]
+        instalment1: request[:instalment1],
+        instalment2: request[:instalment2],
+        instalment3: request[:instalment3],
+        instalment4: request[:instalment4],
+        total: request[:total]
       }
       new_request
     end
@@ -286,19 +286,17 @@ class UI::UseCase::ConvertUIHIFReturn
     @converted_return[:fundingProfiles][:reasonForRequest] = @return[:fundingProfiles][:reasonForRequest]
     @converted_return[:fundingProfiles][:mitigationInPlace] = @return[:fundingProfiles][:mitigationInPlace]
 
-    @converted_return[:fundingProfiles][:requestedProfiles] = @return[:fundingProfiles][:requestedProfiles].map do |request|
+    @converted_return[:fundingProfiles][:requestedProfiles] = @return[:fundingProfiles][:newProfile].map do |request|
       next if request.nil?
 
       new_request = { period: request[:period] }
 
-      next new_request if request[:newProfile].nil?
-
       new_request[:newProfile] = {
-        instalment1: request[:newProfile][:instalment1],
-        instalment2: request[:newProfile][:instalment2],
-        instalment3: request[:newProfile][:instalment3],
-        instalment4: request[:newProfile][:instalment4],
-        total: request[:newProfile][:total]
+        instalment1: request[:instalment1],
+        instalment2: request[:instalment2],
+        instalment3: request[:instalment3],
+        instalment4: request[:instalment4],
+        total: request[:total]
       }
       new_request
     end

--- a/lib/ui/use_case/convert_ui_hif_return.rb
+++ b/lib/ui/use_case/convert_ui_hif_return.rb
@@ -282,11 +282,30 @@ class UI::UseCase::ConvertUIHIFReturn
       }
       new_request
     end
+
+    
+    unless @return[:fundingProfiles][:currentFunding].nil? 
+      @converted_return[:fundingProfiles][:currentFunding] = {}
+
+      @converted_return[:fundingProfiles][:currentFunding][:forecast] = @return[:fundingProfiles][:currentFunding][:forecast].map do |request|
+        next if request.nil?
+        new_profile = {
+          period: request[:period],
+          instalment1: request[:instalment1],
+          instalment2: request[:instalment2],
+          instalment3: request[:instalment3],
+          instalment4: request[:instalment4],
+          total: request[:total]
+        }
+        new_profile
+      end
+    end
+    
     @converted_return[:fundingProfiles][:changeRequired] = @return[:fundingProfiles][:changeRequired]
     @converted_return[:fundingProfiles][:reasonForRequest] = @return[:fundingProfiles][:reasonForRequest]
     @converted_return[:fundingProfiles][:mitigationInPlace] = @return[:fundingProfiles][:mitigationInPlace]
 
-    @converted_return[:fundingProfiles][:requestedProfiles] = @return[:fundingProfiles][:newProfile].map do |request|
+    @converted_return[:fundingProfiles][:requestedProfiles] = @return[:fundingProfiles][:requestedProfiles][:newProfile].map do |request|
       next if request.nil?
 
       new_request = { period: request[:period] }

--- a/spec/acceptance/ui/hif_returns_spec.rb
+++ b/spec/acceptance/ui/hif_returns_spec.rb
@@ -88,7 +88,7 @@ describe 'Interacting with a HIF Return from the UI' do
 
       created_return = dependency_factory.get_use_case(:ui_get_return).execute(id: return_id)[:updates].last
 
-      expect(created_return[:s151]).to eq(expected_updated_return[:s151])
+      expect(created_return).to eq(expected_updated_return)
     end
 
     it 'Allows you to create a return with all the data in' do
@@ -110,7 +110,7 @@ describe 'Interacting with a HIF Return from the UI' do
       created_return_one = created_returns[0][:updates][0]
       created_return_two = created_returns[1][:updates][0]
 
-      expect(created_return_one[:infrastructures]).to eq(hif_get_return[:infrastructures])
+      expect(created_return_one).to eq(hif_get_return)
       expect(created_return_two).to eq(hif_get_return)
     end
   end

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -85,13 +85,14 @@
     "totalHIFGrant": "10000",
     "fundingRequest": [
       {
-        "period": "2019/2020",
-        "forecast": {
-          "instalment1": "1000",
-          "instalment2": "1000",
-          "instalment3": "1000",
-          "instalment4": "1000",
-          "total": "4000"
+      "period": "2019/2020",
+      "forecast":
+        {
+        "instalment1": "1000",
+        "instalment2": "1000",
+        "instalment3": "1000",
+        "instalment4": "1000",
+        "total": "4000"
         }
       },
       {
@@ -105,7 +106,15 @@
         }
       }
     ],
-    "requestedProfiles": [{ "period": "2019/2020" }, {"period": null} ]
+    "currentFunding": {"forecast": []},
+    "requestedProfiles": [
+      {
+        "period": "2019/2020"
+      },
+      {
+        "period": null
+      }
+    ]
   },
   "fundingPackages": [
     {

--- a/spec/fixtures/hif_return_core.json
+++ b/spec/fixtures/hif_return_core.json
@@ -233,6 +233,18 @@
         }
       }
     ],
+    "currentFunding": {
+      "forecast": [
+        {
+          "period": "2019/2020",
+          "instalment1": "1000",
+          "instalment2": "1000",
+          "instalment3": "1000",
+          "instalment4": "1000",
+          "total": "4000"
+        }
+      ]
+    },
     "changeRequired": "Change required",
     "reasonForRequest": "no bricks",
     "mitigationInPlace": "buy more",

--- a/spec/fixtures/hif_return_ui.json
+++ b/spec/fixtures/hif_return_ui.json
@@ -222,33 +222,33 @@
   ],
   "fundingProfiles": {
     "totalHIFGrant": "10000",
-    "fundingRequest": [
-      {
-        "period": "2019/2020",
-        "forecast": {
+    "fundingRequest": {
+      "forecast": [
+        {
+          "period": "2019/2020",
           "instalment1": "1000",
           "instalment2": "1000",
           "instalment3": "1000",
           "instalment4": "1000",
           "total": "4000"
         }
-      }
-    ],
+      ]
+    },
     "changeRequired": "Change required",
     "reasonForRequest": "no bricks",
     "mitigationInPlace": "buy more",
-    "requestedProfiles": [
+    "requestedProfiles": {
+      "newProfile": [
       {
         "period": "2019/2020",
-        "newProfile": {
-          "instalment1": "1000",
-          "instalment2": "1000",
-          "instalment3": "1000",
-          "instalment4": "1000",
-          "total": "4000"
+        "instalment1": "1000",
+        "instalment2": "1000",
+        "instalment3": "1000",
+        "instalment4": "1000",
+        "total": "4000"
         }
-      }
-    ]
+      ]
+    }
   },
   "fundingPackages": [
     {

--- a/spec/fixtures/hif_return_ui.json
+++ b/spec/fixtures/hif_return_ui.json
@@ -234,6 +234,18 @@
         }
       ]
     },
+    "currentFunding": {
+      "forecast": [
+        {
+          "period": "2019/2020",
+          "instalment1": "1000",
+          "instalment2": "1000",
+          "instalment3": "1000",
+          "instalment4": "1000",
+          "total": "4000"
+        }
+      ]
+    },
     "changeRequired": "Change required",
     "reasonForRequest": "no bricks",
     "mitigationInPlace": "buy more",

--- a/spec/fixtures/hif_saved_base_return.json
+++ b/spec/fixtures/hif_saved_base_return.json
@@ -99,32 +99,51 @@
   ],
   "fundingProfiles": {
     "totalHIFGrant": "10000",
-    "fundingRequest": [
-      {
+    "fundingRequest": {
+      "forecast":
+      [
+        {
         "period": "2019/2020",
-        "forecast": {
-          "instalment1": "1000",
-          "instalment2": "1000",
-          "instalment3": "1000",
-          "instalment4": "1000",
-          "total": "4000"
-        }
-      },
-      {
-        "period": null,
-        "forecast": {
+        "instalment1": "1000",
+        "instalment2": "1000",
+        "instalment3": "1000",
+        "instalment4": "1000",
+        "total": "4000"
+        },
+        {
+          "period": null,
           "instalment1": null,
           "instalment2": null,
           "instalment3": null,
           "instalment4": null,
           "total": null
         }
-      }
-    ],
+      ]
+      },
+    "currentFunding": {"forecast":[]},
     "changeRequired": null,
     "reasonForRequest": null,
     "mitigationInPlace": null,
-    "requestedProfiles": [{ "period": "2019/2020" }, { "period": null }]
+    "requestedProfiles": {
+      "newProfile": [
+        {
+          "instalment1": null,
+          "instalment2": null,
+          "instalment3": null,
+          "instalment4": null,
+          "period": "2019/2020",
+          "total": null
+        },
+        {
+          "instalment1": null,
+          "instalment2": null,
+          "instalment3": null,
+          "instalment4": null,
+          "period": null,
+          "total": null
+        }
+      ]
+    } 
   },
   "fundingPackages": [
     {

--- a/spec/fixtures/hif_updated_return.json
+++ b/spec/fixtures/hif_updated_return.json
@@ -98,6 +98,7 @@
             "riskBaselineRisk": "Risk one",
             "riskBaselineImpact": "High",
             "riskBaselineLikelihood": "High",
+            "riskCurrentReturnLikelihood": null,
             "riskBaselineMitigationsInPlace": "Do not do the thing",
             "riskAnyChange": null,
             "riskCurrentReturnMitigationsInPlace": null,
@@ -109,32 +110,51 @@
   ],
   "fundingProfiles": {
     "totalHIFGrant": "10000",
-    "fundingRequest": [
-      {
+    "currentFunding": {"forecast": []},
+    "fundingRequest": {
+      "forecast":
+      [
+        {
         "period": "2019/2020",
-        "forecast": {
-          "instalment1": "1000",
-          "instalment2": "1000",
-          "instalment3": "1000",
-          "instalment4": "1000",
-          "total": "4000"
-        }
-      },
-      {
-        "period": null,
-        "forecast": {
+        "instalment1": "1000",
+        "instalment2": "1000",
+        "instalment3": "1000",
+        "instalment4": "1000",
+        "total": "4000"
+        },
+        {
+          "period": null,
           "instalment1": null,
           "instalment2": null,
           "instalment3": null,
           "instalment4": null,
           "total": null
         }
-      }
-    ],
+      ]
+    },
     "changeRequired": null,
     "reasonForRequest": null,
     "mitigationInPlace": null,
-    "requestedProfiles": [{ "period": "2019/2020" }, { "period": null }]
+    "requestedProfiles": {
+      "newProfile": [
+        {
+          "instalment1": null,
+          "instalment2": null,
+          "instalment3": null,
+          "instalment4": null,
+          "period": "2019/2020",
+          "total": null
+        },
+        {
+          "instalment1": null,
+          "instalment2": null,
+          "instalment3": null,
+          "instalment4": null,
+          "period": null,
+          "total": null
+        }
+      ]
+    }
   },
   "fundingPackages": [
     {

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -88,28 +88,8 @@
   ],
   "fundingProfiles": {
     "totalHIFGrant": "10000",
-    "fundingRequest": [
-      {
-        "period": "2019/2020",
-        "forecast": {
-          "instalment1": "1000",
-          "instalment2": "1000",
-          "instalment3": "1000",
-          "instalment4": "1000",
-          "total": "4000"
-        }
-      },
-      {
-        "period": null,
-        "forecast": {
-          "instalment1": null,
-          "instalment2": null,
-          "instalment3": null,
-          "instalment4": null,
-          "total": null
-        }
-      }
-    ],
+    "fundingRequest": [],
+    "currentFunding": {"forecast": []},
     "requestedProfiles": [{ "period": "2019/2020" }, {"period": null} ]
   },
   "fundingPackages": [

--- a/spec/unit/local_authority/use_case/find_path_data_spec.rb
+++ b/spec/unit/local_authority/use_case/find_path_data_spec.rb
@@ -147,4 +147,62 @@ describe LocalAuthority::UseCase::FindPathData do
       expect(use_case).to eq({})
     end
   end
+
+  context 'deciding between return and baseline data' do
+    context 'return data exists' do
+      let(:baseline_data) do
+        {
+          baseline_data: {
+            infrastructures: {
+              cats: {
+                puppies: 'Get me this data'
+              }
+            }
+          },
+          return_data: {
+            returning_infrastructures: {
+              puppies: 'or this data'
+            }
+          }
+        }
+      end
+      let(:path) do 
+        [
+          :return_or_baseline,
+          [:baseline_data, :infrastructures, :cats, :puppies],
+          [:return_data, :returning_infrastructures, :puppies]
+        ]
+      end
+
+      it 'can get the data from the return data' do
+        expect(use_case).to eq(found: 'or this data')
+      end
+    end
+
+    context 'return data doesnt exist' do
+      let(:baseline_data) do
+        {
+          baseline_data: {
+            infrastructures: {
+              cats: {
+                puppies: 'Get me this data'
+              }
+            }
+          },
+          return_data: {}
+        }
+      end
+      let(:path) do 
+        [
+          :return_or_baseline,
+          [:baseline_data, :infrastructures, :cats, :puppies],
+          [:return_data, :returning_infrastructures, :puppies]
+        ]
+      end
+
+      it 'can get the data from the baseline data' do
+        expect(use_case).to eq(found: 'Get me this data')
+      end
+    end
+  end
 end

--- a/spec/unit/ui/use_case/convert_ui_hif_return_spec.rb
+++ b/spec/unit/ui/use_case/convert_ui_hif_return_spec.rb
@@ -13,7 +13,7 @@ describe UI::UseCase::ConvertUIHIFReturn do
     )
   end
 
-  fit 'Converts the project correctly' do
+  it 'Converts the project correctly' do
     converted_project = described_class.new.execute(return_data: return_to_convert)
 
     expect(converted_project[:fundingPackages]).to eq(core_data_return[:fundingPackages])

--- a/spec/unit/ui/use_case/convert_ui_hif_return_spec.rb
+++ b/spec/unit/ui/use_case/convert_ui_hif_return_spec.rb
@@ -13,7 +13,7 @@ describe UI::UseCase::ConvertUIHIFReturn do
     )
   end
 
-  it 'Converts the project correctly' do
+  fit 'Converts the project correctly' do
     converted_project = described_class.new.execute(return_data: return_to_convert)
 
     expect(converted_project[:fundingPackages]).to eq(core_data_return[:fundingPackages])


### PR DESCRIPTION
- changed the funding profile to quarterly components
- added a hidden profile to chose either previous profile or new profile that was requested
- extend source key so that you can decided to default to baseline if no previous return
- Use this on funding request to pull from baseline if no previous return, if not the hidden profile of previous return.