### PR TITLE
Add weeks passed calculation to various infra fields

### DIFF
--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -554,6 +554,7 @@
                       "laHasControlOfSite": { "enum": ["No"] },
                       "laDoesNotControlSite": {
                         "type": "object",
+                        "calculation": "set(formData['allLandAssemblyAchieved'], 'landAssemblyVarianceAgainstBaseReturn', weeksPassed(get(formData, 'allLandAssemblyAchieved', 'baseline'), get(formData, 'allLandAssemblyAchieved', 'current')));",
                         "title": "Land ownership",
                         "properties": {
                           "whoOwnsSite": {
@@ -642,13 +643,11 @@
                                       "landAssemblyVarianceAgainstLastReturn": {
                                         "type": "string",
                                         "readonly": true,
-                                        "hidden": true,
                                         "title": "Variance Against Last Return (Calculated)"
                                       },
                                       "landAssemblyVarianceAgainstBaseReturn": {
                                         "type": "string",
                                         "readonly": true,
-                                        "hidden": true,
                                         "title": "Variance Against Base Return (Calculated)"
                                       },
                                       "status": {

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -454,6 +454,7 @@
                                 "type": "array",
                                 "items": {
                                   "type": "object",
+                                  "calculation": "set(formData, 'varianceAgainstBaseline', weeksPassed(get(formData, 'baselineCompletion'), get(formData, 'currentReturn')))",
                                   "properties": {
                                     "baselineCompletion": {
                                       "title": "Baseline completion",
@@ -468,13 +469,11 @@
                                       ]
                                     },
                                     "varianceAgainstBaseline": {
-                                      "hidden": true,
                                       "title": "Variance against baseline (Calculated)",
                                       "type": "string",
                                       "readonly": true
                                     },
                                     "varianceAgainstLastReturn": {
-                                      "hidden": true,
                                       "title": "Variance against last return (Calculated)",
                                       "type": "string",
                                       "readonly": true

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -37,7 +37,7 @@
             "properties": {
               "outlinePlanning": {
                 "type": "object",
-                "calculation": "set(formData['planningSubmitted'], 'varianceBaselineFullPlanningPermissionSubmitted', weeksPassed(get(formData, 'planningSubmitted', 'baseline'), get(formData, 'planningSubmitted', 'current')));",
+                "calculation": "set(formData['planningSubmitted'], 'varianceBaselineFullPlanningPermissionSubmitted', weeksPassed(get(formData, 'planningSubmitted', 'baseline'), get(formData, 'planningSubmitted', 'current'))); set(formData['planningGranted'], 'varianceBaselineFullPlanningPermissionSubmitted', weeksPassed(get(formData, 'planningGranted', 'baseline'), get(formData, 'planningGranted', 'current')));",
                 "title": "Outline Planning",
                 "properties": {
                   "baselineOutlinePlanningPermissionGranted": {
@@ -218,6 +218,7 @@
               },
               "fullPlanning": {
                 "type": "object",
+                "calculation": "set(formData['submitted'], 'varianceBaselineFullPlanningPermissionSubmitted', weeksPassed(get(formData, 'submitted', 'baseline'), get(formData, 'submitted', 'current'))); set(formData['granted'], 'varianceBaselineFullPlanningPermissionGranted', weeksPassed(get(formData, 'granted', 'baseline'), get(formData, 'granted', 'current')));",
                 "title": "Full Planning",
                 "properties": {
                   "fullPlanningPermissionGranted": {
@@ -272,13 +273,11 @@
                               "varianceBaselineFullPlanningPermissionSubmitted": {
                                 "type": "string",
                                 "readonly": true,
-                                "hidden": true,
                                 "title": "Variance against Baseline submitted date (Week) (Calculated)"
                               },
                               "varianceLastReturnFullPlanningPermissionSubmitted": {
                                 "type": "string",
                                 "readonly": true,
-                                "hidden": true,
                                 "title": "Variance against Last Return submitted date (Week) (Calculated)"
                               },
                               "status": {


### PR DESCRIPTION
Add weeks difference calculations to:
- All planning fields
- Statutory Consents
- Land Ownership

(Land Ownership is reliant on PR https://github.com/homes-england/monitor-frontend/pull/210 to display the results)