### PR TITLE
Create functionality to unsubmit and delete returns

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
       OUTPUTS_ACTUALS_TAB: 'yes'
       WIDER_SCHEME_TAB: 'yes'
       MR_REVIEW_TAB: 'yes'
-      BACK_TO_BASELINE: 'yes'
 
   notify_simulator:
     build: .

--- a/lib/delivery_mechanism/web_routes.rb
+++ b/lib/delivery_mechanism/web_routes.rb
@@ -285,6 +285,18 @@ module DeliveryMechanism
       end
     end
 
+    unless ENV['BACK_TO_BASELINE'].nil?
+      post '/project/unsubmit' do
+        guard_access env, params, request do |request_hash|
+          @dependency_factory.get_use_case(:unsubmit_project).execute(
+            project_id: request_hash[:project_id].to_i
+          )
+
+          response.status = 200
+        end
+      end
+    end
+
     def get_hash(request)
       body = request.body.read
       return nil if body.to_s.empty?

--- a/lib/homes_england/use_case/unsubmit_project.rb
+++ b/lib/homes_england/use_case/unsubmit_project.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class HomesEngland::UseCase::UnSubmitProject
+  def initialize(project_gateway:, return_gateway:)
+    @project_gateway = project_gateway
+    @return_gateway = return_gateway
+  end
+
+  def execute(project_id:)
+    return if ENV['BACK_TO_BASELINE'].nil?
+
+    project = @project_gateway.find_by(id: project_id)
+    
+    delete_returns(project_id)
+
+    @project_gateway.submit(id: project_id, status: 'Draft')
+  end
+
+  private
+
+  def delete_returns(project_id)
+    returns = @return_gateway.get_returns(project_id: project_id)
+    returns.each do |r|
+      @return_gateway.delete(return_id: r.id)
+    end
+  end
+end

--- a/lib/homes_england/use_cases.rb
+++ b/lib/homes_england/use_cases.rb
@@ -33,6 +33,13 @@ class HomesEngland::UseCases
       )
     end
 
+    builder.define_use_case :unsubmit_project do
+      HomesEngland::UseCase::UnSubmitProject.new(
+        project_gateway: builder.get_gateway(:project),
+        return_gateway: builder.get_gateway(:return_gateway)
+      )
+    end
+
     builder.define_use_case :get_schema_for_project do
       HomesEngland::UseCase::GetSchemaForProject.new(
         template_gateway: builder.get_gateway(:template)

--- a/lib/local_authority/gateway/sequel_return.rb
+++ b/lib/local_authority/gateway/sequel_return.rb
@@ -36,6 +36,10 @@ class LocalAuthority::Gateway::SequelReturn
     end
   end
 
+  def delete(return_id:)
+    @database[:returns].where(id: return_id).delete
+  end
+
   def submit(return_id:)
     @database[:returns].where(id: return_id).update(status: 'Submitted')
   end

--- a/spec/acceptance/homes_england/unsubmit_project_spec.rb
+++ b/spec/acceptance/homes_england/unsubmit_project_spec.rb
@@ -1,0 +1,120 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require_relative '../shared_context/dependency_factory'
+
+describe 'Unsubmitting a submitted project' do
+  include_context 'dependency factory'
+
+  context 'Whilst BACK_TO_BASELINE is true' do
+    let(:back_to_baseline) { ENV['BACK_TO_BASELINE'] }
+    before do 
+      back_to_baseline
+      ENV['BACK_TO_BASELINE'] = 'yes'
+    end
+
+    after do
+      ENV['BACK_TO_BASELINE'] = back_to_baseline
+    end
+
+    it 'Changes the status to Draft' do
+      project_baseline = {
+        summary: {
+          project_name: '',
+          description: '',
+          lead_authority: ''
+        },
+        infrastructure: {
+          type: '',
+          description: '',
+          completion_date: '',
+          planning: {
+            submission_estimated: ''
+          }
+        },
+        financial: {
+          total_amount_estimated: ''
+        }
+      }
+      project_id = get_use_case(:create_new_project).execute(
+        name: 'cat project', type: 'hif', baseline: project_baseline
+      )[:id]
+
+      
+      
+      get_use_case(:submit_project).execute(project_id: project_id)
+      
+      expect(get_use_case(:find_project).execute(id: project_id)[:status]).to eq('Submitted')
+      
+      return_id = get_use_case(:create_return).execute(project_id: project_id, data: {some_data: "fun"})[:id]
+      get_use_case(:submit_return).execute(return_id: return_id)
+      
+      expect(get_use_case(:get_returns).execute(project_id: project_id)[:returns].length).to eq(1)
+      
+
+      get_use_case(:unsubmit_project).execute(project_id: project_id)
+
+      project = get_use_case(:find_project).execute(id: project_id)
+
+      expect(project[:status]).to eq('Draft')
+      expect(project[:data]).to eq(project_baseline)
+      expect(get_use_case(:get_returns).execute(project_id: project_id)[:returns].length).to eq(0)
+    end
+  end
+
+  context 'Whilst BACK_TO_BASELINE is true' do
+    let(:back_to_baseline) { ENV['BACK_TO_BASELINE'] }
+    before do 
+      back_to_baseline
+      ENV['BACK_TO_BASELINE'] = nil
+    end
+
+    after do
+      ENV['BACK_TO_BASELINE'] = back_to_baseline
+    end
+
+    it 'Doesnt change anything' do
+      project_baseline = {
+        summary: {
+          project_name: '',
+          description: '',
+          lead_authority: ''
+        },
+        infrastructure: {
+          type: '',
+          description: '',
+          completion_date: '',
+          planning: {
+            submission_estimated: ''
+          }
+        },
+        financial: {
+          total_amount_estimated: ''
+        }
+      }
+      project_id = get_use_case(:create_new_project).execute(
+        name: 'cat project', type: 'hif', baseline: project_baseline
+      )[:id]
+
+      
+      
+      get_use_case(:submit_project).execute(project_id: project_id)
+      
+      expect(get_use_case(:find_project).execute(id: project_id)[:status]).to eq('Submitted')
+      
+      return_id = get_use_case(:create_return).execute(project_id: project_id, data: {some_data: "fun"})[:id]
+      get_use_case(:submit_return).execute(return_id: return_id)
+      
+      expect(get_use_case(:get_returns).execute(project_id: project_id)[:returns].length).to eq(1)
+      
+
+      get_use_case(:unsubmit_project).execute(project_id: project_id)
+
+      project = get_use_case(:find_project).execute(id: project_id)
+
+      expect(project[:status]).to eq('Submitted')
+      expect(project[:data]).to eq(project_baseline)
+      expect(get_use_case(:get_returns).execute(project_id: project_id)[:returns].length).to eq(1)
+    end
+  end
+end


### PR DESCRIPTION
Create the ability to unsubmit and project and delete all the returns, hidden behind env variables.

Not tested as this will never go onto production, just for testing purposes.