### PR TITLE
Add timestamp to returns

### DIFF
--- a/db/migrations/13_add_timestamp_to_returns.rb
+++ b/db/migrations/13_add_timestamp_to_returns.rb
@@ -1,0 +1,7 @@
+Sequel.migration do
+  change do
+    alter_table(:returns) do
+      add_column :timestamp, Integer, default: 0
+    end
+  end
+end

--- a/lib/local_authority/domain/return.rb
+++ b/lib/local_authority/domain/return.rb
@@ -1,5 +1,5 @@
 class LocalAuthority::Domain::Return
-  attr_accessor :id, :project_id, :type, :status, :updates
+  attr_accessor :id, :project_id, :type, :status, :updates, :timestamp
   def initialize
     @status = 'Draft'
   end

--- a/lib/local_authority/gateway/sequel_return.rb
+++ b/lib/local_authority/gateway/sequel_return.rb
@@ -23,6 +23,7 @@ class LocalAuthority::Gateway::SequelReturn
       r.type = row[:type]
       r.project_id = row[:project_id]
       r.status = row[:return_status]
+      r.timestamp = row[:timestamp]
     end
   end
 
@@ -32,6 +33,7 @@ class LocalAuthority::Gateway::SequelReturn
         r.id = db_r[:id]
         r.project_id = db_r[:project_id]
         r.status = db_r[:status]
+        r.timestamp = db_r[:timestamp]
       end
     end
   end

--- a/lib/local_authority/gateway/sequel_return.rb
+++ b/lib/local_authority/gateway/sequel_return.rb
@@ -40,7 +40,8 @@ class LocalAuthority::Gateway::SequelReturn
     @database[:returns].where(id: return_id).delete
   end
 
-  def submit(return_id:)
+  def submit(return_id:, timestamp:)
     @database[:returns].where(id: return_id).update(status: 'Submitted')
+    @database[:returns].where(id: return_id).update(timestamp: timestamp)
   end
 end

--- a/lib/local_authority/use_case/get_return.rb
+++ b/lib/local_authority/use_case/get_return.rb
@@ -31,7 +31,8 @@ class LocalAuthority::UseCase::GetReturn
         type: found_return.type,
         project_id: found_return.project_id,
         status: found_return.status,
-        updates: updates.map(&:data)
+        updates: updates.map(&:data),
+        timestamp: found_return.timestamp
       }
     end
   end

--- a/lib/local_authority/use_case/get_returns.rb
+++ b/lib/local_authority/use_case/get_returns.rb
@@ -13,7 +13,8 @@ class LocalAuthority::UseCase::GetReturns
           id: r.id,
           project_id: r.project_id,
           status: r.status,
-          updates: @return_update_gateway.updates_for(return_id: r.id).map(&:data)
+          updates: @return_update_gateway.updates_for(return_id: r.id).map(&:data),
+          timestamp: r.timestamp
         }
       end
     }

--- a/lib/local_authority/use_case/submit_return.rb
+++ b/lib/local_authority/use_case/submit_return.rb
@@ -4,6 +4,7 @@ class LocalAuthority::UseCase::SubmitReturn
   end
 
   def execute(return_id:)
-    @return_gateway.submit(return_id: return_id)
+    timestamp = Time.now.to_i
+    @return_gateway.submit(return_id: return_id, timestamp: timestamp)
   end
 end

--- a/spec/acceptance/local_authority/calculate_hif_return_spec.rb
+++ b/spec/acceptance/local_authority/calculate_hif_return_spec.rb
@@ -113,7 +113,8 @@ describe 'Calculated return' do
       updates: [
         expected_return_data
       ],
-      status: 'Draft'
+      status: 'Draft',
+      timestamp: 0
     }
 
     expect(get_use_case(:get_return).execute(id: return2_id)).to(

--- a/spec/acceptance/local_authority/get_returns_spec.rb
+++ b/spec/acceptance/local_authority/get_returns_spec.rb
@@ -1,5 +1,6 @@
 require 'rspec'
 require_relative '../shared_context/dependency_factory'
+require 'timecop'
 
 describe 'Getting multiple returns' do
   include_context 'dependency factory'
@@ -69,6 +70,10 @@ describe 'Getting multiple returns' do
       project_id: project_id, data: { dogs: 'woof' }
     )[:id]
 
+    time_now = Time.now
+    Timecop.freeze(time_now)
+    time_now = time_now.to_i
+
     expected_returns = [
       {
         id: return1_id,
@@ -76,7 +81,8 @@ describe 'Getting multiple returns' do
         updates: [
           { cats: 'meow' }
         ],
-        status: 'Submitted'
+        status: 'Submitted',
+        timestamp: time_now
       },
       {
         id: return2_id,
@@ -84,7 +90,8 @@ describe 'Getting multiple returns' do
         updates: [
           { dogs: 'woof' }
         ],
-        status: 'Draft'
+        status: 'Draft',
+        timestamp: 0
       }
     ]
 

--- a/spec/unit/local_authority/gateway/sequel_return_spec.rb
+++ b/spec/unit/local_authority/gateway/sequel_return_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 describe LocalAuthority::Gateway::SequelReturn do
   include_context 'with database'
 
@@ -29,6 +31,7 @@ describe LocalAuthority::Gateway::SequelReturn do
       expect(found_return.type).to eq('hif')
       expect(found_return.project_id).to eq(project_id)
       expect(found_return.status).to eq('Draft')
+      expect(found_return.timestamp).to eq(0)
     end
   end
 
@@ -55,6 +58,7 @@ describe LocalAuthority::Gateway::SequelReturn do
       expect(found_return.type).to eq('ac')
       expect(found_return.project_id).to eq(project_id)
       expect(found_return.status).to eq('Submitted')
+      expect(found_return.timestamp).to eq(0)
     end
   end
 

--- a/spec/unit/local_authority/use_case/get_returns_spec.rb
+++ b/spec/unit/local_authority/use_case/get_returns_spec.rb
@@ -33,6 +33,7 @@ describe LocalAuthority::UseCase::GetReturns do
             r.id = 2
             r.project_id = 1
             r.status = 'Draft'
+            r.timestamp = 1234
           end
         ]
       end
@@ -60,7 +61,8 @@ describe LocalAuthority::UseCase::GetReturns do
               status: 'Draft',
               updates: [
                 { cats: 'Meow' }
-              ]
+              ],
+              timestamp: 1234
             }
           ]
         )
@@ -89,7 +91,8 @@ describe LocalAuthority::UseCase::GetReturns do
                 updates: [
                   { cats: 'Meow' },
                   { birds: 'chirp' }
-                ]
+                ],
+                timestamp: 1234
               }
             ]
           )
@@ -120,11 +123,13 @@ describe LocalAuthority::UseCase::GetReturns do
             r.id = 2
             r.project_id = 1
             r.status = 'Draft'
+            r.timestamp = 123
           end,
           LocalAuthority::Domain::Return.new.tap do |r|
             r.id = 8
             r.project_id = 6
             r.status = 'Submitted'
+            r.timestamp = 321
           end
         ]
       end
@@ -173,7 +178,8 @@ describe LocalAuthority::UseCase::GetReturns do
               updates: [
                 { cats: 'Meow' },
                 { birds: 'chirp' }
-              ]
+              ],
+              timestamp: 123
             }, {
               id: 8,
               project_id: 6,
@@ -181,7 +187,8 @@ describe LocalAuthority::UseCase::GetReturns do
               updates: [
                 { dogs: 'woof' },
                 { cows: 'moo' }
-              ]
+              ],
+              timestamp: 321
             }
           ]
         )
@@ -209,6 +216,7 @@ describe LocalAuthority::UseCase::GetReturns do
             r.id = 4
             r.project_id = 3
             r.status = 'Submitted'
+            r.timestamp = 987
           end
         ]
       end
@@ -237,7 +245,8 @@ describe LocalAuthority::UseCase::GetReturns do
                 status: 'Submitted',
                 updates: [
                   { dogs: 'woof' }
-                ]
+                ],
+                timestamp: 987
               }
             ]
           )
@@ -267,7 +276,8 @@ describe LocalAuthority::UseCase::GetReturns do
                 updates: [
                   { dogs: 'woof' },
                   { cows: 'moo'}
-                ]
+                ],
+                timestamp: 987
               }
             ]
           )

--- a/spec/unit/local_authority/use_case/submit_return_spec.rb
+++ b/spec/unit/local_authority/use_case/submit_return_spec.rb
@@ -1,19 +1,27 @@
 # frozen_string_literal: true
 
+require 'timecop'
+
 describe LocalAuthority::UseCase::SubmitReturn do
   let(:return_gateway) { spy }
-  let(:use_case) {described_class.new(return_gateway: return_gateway)}
+  let(:use_case) { described_class.new(return_gateway: return_gateway) }
   context 'example 1' do
-    it 'should submit an id to the return gateway' do
+    it 'should submit an id and timestamp to the return gateway' do
+      time_now = Time.now
+      Timecop.freeze(time_now)
+      time_now = time_now.to_i
       use_case.execute(return_id: 1)
-      expect(return_gateway).to have_received(:submit).with(return_id: 1)
+      expect(return_gateway).to have_received(:submit).with(return_id: 1, timestamp: time_now)
     end
   end
 
   context 'example 2' do
-    it 'should submit an id to the return gateway' do
+    it 'should submit an id and timestamp to the return gateway' do
+      time_now = Time.now
+      Timecop.freeze(time_now)
+      time_now = time_now.to_i
       use_case.execute(return_id: 4)
-      expect(return_gateway).to have_received(:submit).with(return_id: 4)
+      expect(return_gateway).to have_received(:submit).with(return_id: 4, timestamp: time_now)
     end
   end
 end


### PR DESCRIPTION
This PR creates a fixed timestamp upon submission and passes this to the front end for use in the returns list component.