### PR TITLE
In year housing stats

### DIFF
--- a/lib/local_authority/gateway/hif_returns_schema.rb
+++ b/lib/local_authority/gateway/hif_returns_schema.rb
@@ -2148,6 +2148,91 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
           type: "object",
           title: "In Year Housing Starts",
           properties: {
+            newYear: {
+              type: "object",
+              title: "",
+              properties: {
+                setNewAmounts: {
+                  type: "string",
+                  title: "  ",
+                  enum: ["Set this years forecasted amounts.", "This years amounts have already been set."],
+                  radio: true
+                }
+              },
+              dependencies: {
+                setNewAmounts: {
+                  oneOf: [
+                    {
+                      properties: {
+                        setNewAmounts: {
+                          enum: ["Set this years forecasted housing starts."]
+                        },
+                        newStarts: {
+                          type: "object",
+                          horizontal: true,
+                          title: "This Years Forecasted Amounts",
+                          properties: {
+                            quarter1: {
+                              type: "string",
+                              title: "Q1 Current Year"
+                            },
+                            quarter2: {
+                              type: "string",
+                              title: "Q2 Current Year"
+                            },
+                            quarter3: {
+                              type: "string",
+                              title: "Q3 Current Year"
+                            },
+                            quarter4: {
+                              type: "string",
+                              title: "Q4 Current Year"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      properties: {
+                        setNewAmounts: {
+                          enum: ["This years housing starts have already been set."]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            currentAmounts: {
+              type: "object",
+              title: "Forecasted Amounts",
+              properties: {
+                quarter1: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter1],
+                  title: "Q1 Current Year"
+                },
+                quarter2: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter2],
+                  title: "Q2 Current Year"
+                },
+                quarter3: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter3],
+                  title: "Q3 Current Year"
+                },
+                quarter4: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter4],
+                  title: "Q4 Current Year"
+                }
+              }
+            },
             baselineAmounts: {
               type: "object",
               horizontal: true,
@@ -2155,18 +2240,22 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
               properties: {
                 quarter1:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter1],
                   title: "Q1 Current Year"
                 },
                 quarter2:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter2],
                   title: "Q2 Current Year"
                 },
                 quarter3:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter3],
                   title: "Q3 Current Year"
                 },
                 quarter4:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts currentAmounts quarter4],
                   title: "Q4 Current Year"
                 }
               }
@@ -2178,18 +2267,22 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
               properties: {
                 quarter1:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts actualAmounts quarter1],
                   title: "Q1 Current Year"
                 },
                 quarter2:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts actualAmounts quarter2],
                   title: "Q2 Current Year"
                 },
                 quarter3:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts actualAmounts quarter3],
                   title: "Q3 Current Year"
                 },
                 quarter4:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingStarts actualAmounts quarter4],
                   title: "Q4 Current Year"
                 }
               }
@@ -2276,8 +2369,93 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
         },
         inYearHousingCompletions: {
           type: "object",
-          title: "In Year Housing Starts",
+          title: "In Year Housing Completions",
           properties: {
+            newYear: {
+              type: "object",
+              title: "",
+              properties: {
+                setNewAmounts: {
+                  type: "string",
+                  title: "  ",
+                  enum: ["Set this years forecasted amounts.", "This years amounts have already been set."],
+                  radio: true
+                }
+              },
+              dependencies: {
+                setNewAmounts: {
+                  oneOf: [
+                    {
+                      properties: {
+                        setNewAmounts: {
+                          enum: ["Set this years forecasted housing starts."]
+                        },
+                        newCompletions: {
+                          type: "object",
+                          horizontal: true,
+                          title: "This Years Forecasted Amounts",
+                          properties: {
+                            quarter1: {
+                              type: "string",
+                              title: "Q1 Current Year"
+                            },
+                            quarter2: {
+                              type: "string",
+                              title: "Q2 Current Year"
+                            },
+                            quarter3: {
+                              type: "string",
+                              title: "Q3 Current Year"
+                            },
+                            quarter4: {
+                              type: "string",
+                              title: "Q4 Current Year"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      properties: {
+                        setNewAmounts: {
+                          enum: ["This years housing starts have already been set."]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            currentAmounts: {
+              type: "object",
+              title: "Forecasted Amounts",
+              properties: {
+                quarter1: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter1],
+                  title: "Q1 Current Year"
+                },
+                quarter2: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter2],
+                  title: "Q2 Current Year"
+                },
+                quarter3: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter3],
+                  title: "Q3 Current Year"
+                },
+                quarter4: {
+                  type: "string",
+                  hidden: true,
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter4],
+                  title: "Q4 Current Year"
+                }
+              }
+            },
             baselineAmounts: {
               type: "object",
               horizontal: true,
@@ -2285,18 +2463,22 @@ class LocalAuthority::Gateway::HIFReturnsSchemaTemplate
               properties: {
                 quarter1:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter1],
                   title: "Q1 Current Year"
                 },
                 quarter2:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter2],
                   title: "Q2 Current Year"
                 },
                 quarter3:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter3],
                   title: "Q3 Current Year"
                 },
                 quarter4:{
                   type: "string",
+                  sourceKey: %i[return_data outputsForecast inYearHousingCompletions currentAmounts quarter4],
                   title: "Q4 Current Year"
                 }
               }

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -5610,28 +5610,113 @@
         },
         "inYearHousingStarts": {
           "type": "object",
-          "title": "In Year Housing Starts",
-          "calculation": "get(formData, 'baselineAmounts') ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
+          "title": "",
+          "calculation": "( get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newStarts')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;get(formData, 'baselineAmounts') ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
           "properties": {
-            "baselineAmounts": {
+            "newYear": {
               "type": "object",
-              "horizontal": true,
-              "title": "Baseline Amounts",
+              "title": "In Year Housing Starts",
+              "properties": {
+                "setNewAmounts": {
+                  "type": "string",
+                  "title": " ",
+                  "enum": ["Set this years target.", "This years target has already been set."],
+                  "radio": true
+                }
+              },
+              "dependencies": {
+                "setNewAmounts": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "setNewAmounts": {
+                          "enum": ["Set this years target."]
+                        },
+                        "newStarts": {
+                          "type": "object",
+                          "horizontal": true,
+                          "title": "This Years Forecasted Amounts",
+                          "properties": {
+                            "quarter1": {
+                              "type": "string",
+                              "title": "Q1 Current Year"
+                            },
+                            "quarter2": {
+                              "type": "string",
+                              "title": "Q2 Current Year"
+                            },
+                            "quarter3": {
+                              "type": "string",
+                              "title": "Q3 Current Year"
+                            },
+                            "quarter4": {
+                              "type": "string",
+                              "title": "Q4 Current Year"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "setNewAmounts": {
+                          "enum": ["This years target has already been set."]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "currentAmounts": {
+              "type": "object",
+              "title": "",
               "properties": {
                 "quarter1": {
                   "type": "string",
+                  "hidden": true,
                   "title": "Q1 Current Year"
                 },
                 "quarter2": {
                   "type": "string",
+                  "hidden": true,
                   "title": "Q2 Current Year"
                 },
                 "quarter3": {
                   "type": "string",
+                  "hidden": true,
                   "title": "Q3 Current Year"
                 },
                 "quarter4": {
                   "type": "string",
+                  "hidden": true,
+                  "title": "Q4 Current Year"
+                }
+              }
+            },
+            "baselineAmounts": {
+              "type": "object",
+              "horizontal": true,
+              "title": "Forecasted Amounts",
+              "properties": {
+                "quarter1": {
+                  "type": "string",
+                  "readonly": true,
+                  "title": "Q1 Current Year"
+                },
+                "quarter2": {
+                  "type": "string",
+                  "readonly": true,
+                  "title": "Q2 Current Year"
+                },
+                "quarter3": {
+                  "type": "string",
+                  "readonly": true,
+                  "title": "Q3 Current Year"
+                },
+                "quarter4": {
+                  "type": "string",
+                  "readonly": true,
                   "title": "Q4 Current Year"
                 }
               }
@@ -5750,28 +5835,113 @@
         },
         "inYearHousingCompletions": {
           "type": "object",
-          "title": "In Year Housing Completions",
-          "calculation": "formData['baselineAmounts'] ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
+          "title": "",
+          "calculation": "( get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newCompletions')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;formData['baselineAmounts'] ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
           "properties": {
-            "baselineAmounts": {
+            "newYear": {
               "type": "object",
-              "horizontal": true,
-              "title": "Baseline Amounts",
+              "title": "In Year Housing Completions",
+              "properties": {
+                "setNewAmounts": {
+                  "type": "string",
+                  "title": " ",
+                  "enum": ["Set this years target.", "This years target has already been set."],
+                  "radio": true
+                }
+              },
+              "dependencies": {
+                "setNewAmounts": {
+                  "oneOf": [
+                    {
+                      "properties": {
+                        "setNewAmounts": {
+                          "enum": ["Set this years target."]
+                        },
+                        "newCompletions": {
+                          "type": "object",
+                          "horizontal": true,
+                          "title": "This Years Forecasted Amounts",
+                          "properties": {
+                            "quarter1": {
+                              "type": "string",
+                              "title": "Q1 Current Year"
+                            },
+                            "quarter2": {
+                              "type": "string",
+                              "title": "Q2 Current Year"
+                            },
+                            "quarter3": {
+                              "type": "string",
+                              "title": "Q3 Current Year"
+                            },
+                            "quarter4": {
+                              "type": "string",
+                              "title": "Q4 Current Year"
+                            }
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "properties": {
+                        "setNewAmounts": {
+                          "enum": ["This years target has already been set."]
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "currentAmounts": {
+              "type": "object",
+              "title": "",
               "properties": {
                 "quarter1": {
                   "type": "string",
+                  "hidden": true,
                   "title": "Q1 Current Year"
                 },
                 "quarter2": {
+                  "type": "string",
+                  "hidden": true,
+                  "title": "Q2 Current Year"
+                },
+                "quarter3": {
+                  "type": "string",
+                  "hidden": true,
+                  "title": "Q3 Current Year"
+                },
+                "quarter4": {
+                  "type": "string",
+                  "hidden": true,
+                  "title": "Q4 Current Year"
+                }
+              }
+            },
+            "baselineAmounts": {
+              "type": "object",
+              "horizontal": true,
+              "title": "Forecasted Amounts",
+              "properties": {
+                "quarter1": {
+                  "type": "string",
+                  "readonly": true,
+                  "title": "Q1 Current Year"
+                },
+                "quarter2": {
+                  "readonly": true,
                   "type": "string",
                   "title": "Q2 Current Year"
                 },
                 "quarter3": {
                   "type": "string",
+                  "readonly": true,
                   "title": "Q3 Current Year"
                 },
                 "quarter4": {
                   "type": "string",
+                  "readonly": true,
                   "title": "Q4 Current Year"
                 }
               }

--- a/lib/ui/gateway/schemas/hif_return.json
+++ b/lib/ui/gateway/schemas/hif_return.json
@@ -5611,7 +5611,7 @@
         "inYearHousingStarts": {
           "type": "object",
           "title": "",
-          "calculation": "( get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newStarts')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;get(formData, 'baselineAmounts') ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
+          "calculation": "(get(formData,'actualAmounts') && get(formData, 'baselineAmounts')) ? set(formData, 'progress', calculateVariance(sum(get(formData,'actualAmounts'), 'quarter1','quarter2','quarter3','quarter4'), sum(get(formData, 'baselineAmounts'), 'quarter1', 'quarter2', 'quarter3', 'quarter4'))): null;(get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newStarts')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;get(formData, 'baselineAmounts') ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
           "properties": {
             "newYear": {
               "type": "object",
@@ -5836,7 +5836,7 @@
         "inYearHousingCompletions": {
           "type": "object",
           "title": "",
-          "calculation": "( get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newCompletions')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;formData['baselineAmounts'] ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
+          "calculation": "(get(formData,'actualAmounts') && get(formData, 'baselineAmounts')) ? set(formData, 'progress', calculateVariance(sum(get(formData,'actualAmounts'), 'quarter1','quarter2','quarter3','quarter4'), sum(get(formData, 'baselineAmounts'), 'quarter1', 'quarter2', 'quarter3', 'quarter4'))): null;( get(formData, 'newYear') && get(formData, 'newYear', 'setNewAmounts') === 'Set this years target.' )? set(formData, 'currentAmounts', get(formData, 'newYear', 'newCompletions')) : set(formData, 'currentAmounts', get(formData, 'baselineAmounts')) ;formData['baselineAmounts'] ? set(formData, 'progress', calculateVariance(sum(formData['actualAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'), sum(formData['baselineAmounts'], 'quarter1', 'quarter2', 'quarter3', 'quarter4'))) : '0'; ",
           "properties": {
             "newYear": {
               "type": "object",

--- a/lib/ui/use_case/convert_core_hif_return.rb
+++ b/lib/ui/use_case/convert_core_hif_return.rb
@@ -669,10 +669,27 @@ class UI::UseCase::ConvertCoreHIFReturn
 
     unless @return[:outputsForecast][:inYearHousingStarts].nil?
       @converted_return[:outputsForecast][:inYearHousingStarts] = {
-        baselineAmounts: @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts],
-        actualAmounts: @return[:outputsForecast][:inYearHousingStarts][:actualAmounts],
         progress: @return[:outputsForecast][:inYearHousingStarts][:progress]
       }
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:baselineAmounts] = @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:currentAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:currentAmounts] = @return[:outputsForecast][:inYearHousingStarts][:currentAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:actualAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:actualAmounts] = @return[:outputsForecast][:inYearHousingStarts][:actualAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:newYear].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:newYear] = {
+          setNewAmounts: @return[:outputsForecast][:inYearHousingStarts][:newYear][:setNewAmounts],
+          newStarts: @return[:outputsForecast][:inYearHousingStarts][:newYear][:newStarts]
+        }
+      end
     end
 
     unless @return[:outputsForecast][:housingCompletions].nil?
@@ -698,10 +715,27 @@ class UI::UseCase::ConvertCoreHIFReturn
 
     unless @return[:outputsForecast][:inYearHousingCompletions].nil?
       @converted_return[:outputsForecast][:inYearHousingCompletions] = {
-        baselineAmounts: @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts],
-        actualAmounts: @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts],
         progress: @return[:outputsForecast][:inYearHousingCompletions][:progress]
       }
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:currentAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:currentAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:currentAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:actualAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:newYear].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:newYear] = {
+          setNewAmounts: @return[:outputsForecast][:inYearHousingCompletions][:newYear][:setNewAmounts],
+          newCompletions: @return[:outputsForecast][:inYearHousingCompletions][:newYear][:newCompletions]
+        }
+      end
     end
   end
 

--- a/lib/ui/use_case/convert_ui_hif_return.rb
+++ b/lib/ui/use_case/convert_ui_hif_return.rb
@@ -672,10 +672,27 @@ class UI::UseCase::ConvertUIHIFReturn
 
     unless @return[:outputsForecast][:inYearHousingStarts].nil?
       @converted_return[:outputsForecast][:inYearHousingStarts] = {
-        baselineAmounts: @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts],
-        actualAmounts: @return[:outputsForecast][:inYearHousingStarts][:actualAmounts],
         progress: @return[:outputsForecast][:inYearHousingStarts][:progress]
       }
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:baselineAmounts] = @return[:outputsForecast][:inYearHousingStarts][:baselineAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:currentAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:currentAmounts] = @return[:outputsForecast][:inYearHousingStarts][:currentAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:actualAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:actualAmounts] = @return[:outputsForecast][:inYearHousingStarts][:actualAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingStarts][:newYear].nil?
+        @converted_return[:outputsForecast][:inYearHousingStarts][:newYear] = {
+          setNewAmounts: @return[:outputsForecast][:inYearHousingStarts][:newYear][:setNewAmounts],
+          newStarts: @return[:outputsForecast][:inYearHousingStarts][:newYear][:newStarts]
+        }
+      end
     end
 
     unless @return[:outputsForecast][:housingCompletions].nil?
@@ -701,10 +718,27 @@ class UI::UseCase::ConvertUIHIFReturn
 
     unless @return[:outputsForecast][:inYearHousingCompletions].nil?
       @converted_return[:outputsForecast][:inYearHousingCompletions] = {
-        baselineAmounts: @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts],
-        actualAmounts: @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts],
         progress: @return[:outputsForecast][:inYearHousingCompletions][:progress]
       }
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:baselineAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:currentAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:currentAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:currentAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:actualAmounts] = @return[:outputsForecast][:inYearHousingCompletions][:actualAmounts]
+      end
+
+      unless @return[:outputsForecast][:inYearHousingCompletions][:newYear].nil?
+        @converted_return[:outputsForecast][:inYearHousingCompletions][:newYear] = {
+          setNewAmounts: @return[:outputsForecast][:inYearHousingCompletions][:newYear][:setNewAmounts],
+          newCompletions: @return[:outputsForecast][:inYearHousingCompletions][:newYear][:newCompletions]
+        }
+      end
     end
   end
 

--- a/spec/acceptance/local_authority/perform_return_spec.rb
+++ b/spec/acceptance/local_authority/perform_return_spec.rb
@@ -221,6 +221,24 @@ describe 'Performing Return on HIF Project' do
           }
         }
       ],
+      outputsForecast: {
+        inYearHousingStarts: {
+          currentAmounts: {
+            quarter1: '12',
+            quarter2: '23',
+            quarter3: '34',
+            quarter4: '45'
+          }
+        },
+        inYearHousingCompletions: {
+          currentAmounts: {
+            quarter1: '12',
+            quarter2: '23',
+            quarter3: '34',
+            quarter4: '45'
+          }
+        }
+      },
       funding: [
         {
           fundingPackages: [

--- a/spec/fixtures/base_return.json
+++ b/spec/fixtures/base_return.json
@@ -160,6 +160,40 @@
       "totalUnits": "10",
       "disposalStrategy": "Disposal strategy"
     },
+    "inYearHousingCompletions": {
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      }
+    },
+    "inYearHousingStarts": {
+      "actualAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      }
+    },
     "housingStarts": {
       "baselineAmounts": [
         { "period": "18/19", "baselineAmounts": "100" },

--- a/spec/fixtures/hif_return_core.json
+++ b/spec/fixtures/hif_return_core.json
@@ -408,6 +408,21 @@
       ]
     },
     "inYearHousingStarts": {
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newStarts": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
       "baselineAmounts": {
         "quarter1": "2",
         "quarter2": "4",
@@ -440,6 +455,21 @@
       ]
     },
     "inYearHousingCompletions": {
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newCompletions": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
       "baselineAmounts": {
         "quarter1": "20",
         "quarter2": "40",

--- a/spec/fixtures/hif_return_ui.json
+++ b/spec/fixtures/hif_return_ui.json
@@ -420,6 +420,21 @@
       ]
     },
     "inYearHousingStarts": {
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newStarts": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
       "baselineAmounts": {
         "quarter1": "2",
         "quarter2": "4",
@@ -452,6 +467,21 @@
       ]
     },
     "inYearHousingCompletions": {
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newCompletions": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
       "baselineAmounts": {
         "quarter1": "20",
         "quarter2": "40",

--- a/spec/fixtures/hif_return_ui_after_calcs.json
+++ b/spec/fixtures/hif_return_ui_after_calcs.json
@@ -428,6 +428,21 @@
       ]
     },
     "inYearHousingStarts": {
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newStarts": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
       "baselineAmounts": {
         "quarter1": "2",
         "quarter2": "4",
@@ -460,6 +475,21 @@
       ]
     },
     "inYearHousingCompletions": {
+      "currentAmounts": {
+        "quarter1": "4",
+        "quarter2": "8",
+        "quarter3": "16",
+        "quarter4": "32"
+      },
+      "newYear": {
+        "setNewAmounts": "Yes",
+        "newCompletions": {
+          "quarter1": "8",
+          "quarter2": "16",
+          "quarter3": "32",
+          "quarter4": "64"
+        }
+      },
       "baselineAmounts": {
         "quarter1": "20",
         "quarter2": "40",

--- a/spec/fixtures/hif_saved_base_return_ui.json
+++ b/spec/fixtures/hif_saved_base_return_ui.json
@@ -220,6 +220,42 @@
       "anyChanges": null,
       "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
     },
+    "inYearHousingCompletions": {
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "progress": null
+    },
+    "inYearHousingStarts": {
+      "actualAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "progress": null
+    },
     "housingCompletions": {
       "baselineAmounts": [
         { "period": "18/19", "baselineAmounts": "0" },

--- a/spec/fixtures/hif_updated_return_ui.json
+++ b/spec/fixtures/hif_updated_return_ui.json
@@ -231,6 +231,42 @@
       "anyChanges": null,
       "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
     },
+    "inYearHousingCompletions": {
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "progress": null
+    },
+    "inYearHousingStarts": {
+      "actualAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "baselineAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "progress": null
+    },
     "housingCompletions": {
       "baselineAmounts": [
         { "period": "18/19", "baselineAmounts": "0" },

--- a/spec/fixtures/second_base_return.json
+++ b/spec/fixtures/second_base_return.json
@@ -181,12 +181,46 @@
       ],
       "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
     },
+    "inYearHousingStarts": {
+      "actualAmounts": {
+        "quarter1": null,
+        "quarter2": null,
+        "quarter3": null,
+        "quarter4": null
+      },
+      "currentAmounts": {
+        "quarter1": "12",
+        "quarter2": "23",
+        "quarter3": "34",
+        "quarter4": "45"
+      },
+      "baselineAmounts": {
+        "quarter1": "12",
+        "quarter2": "23",
+        "quarter3": "34",
+        "quarter4": "45"
+      }
+    },
     "housingCompletions": {
       "baselineAmounts": [
         { "period": "18/19", "baselineAmounts": "0" },
         { "period": "19/20", "baselineAmounts": "50" }
       ],
       "currentReturnAmounts": [{ "period": "18/19" }, { "period": "19/20" }]
+    },
+    "inYearHousingCompletions": {
+      "currentAmounts": {
+        "quarter1": "12",
+        "quarter2": "23",
+        "quarter3": "34",
+        "quarter4": "45"
+      },
+      "baselineAmounts": {
+        "quarter1": "12",
+        "quarter2": "23",
+        "quarter3": "34",
+        "quarter4": "45"
+      }
     }
   },
   "outputsActuals": {


### PR DESCRIPTION
Add option to add housing starts and completions at the beginning of the year. 
Calculate progress percentage of actual vs forecasted