### PR TITLE
Validation to report on dependency errors

### DIFF
--- a/lib/ui/use_case/validate_project.rb
+++ b/lib/ui/use_case/validate_project.rb
@@ -12,7 +12,6 @@ class UI::UseCase::ValidateProject
     project_data = compact_data(project_data)
     
     invalid_paths = schema.invalid_paths(project_data)
-
     invalid_pretty_paths = invalid_paths.map do |path|
       @get_project_template_path_titles.execute(path: path, schema: schema.schema)[:path_titles]
     end

--- a/spec/acceptance/local_authority/validate_return_spec.rb
+++ b/spec/acceptance/local_authority/validate_return_spec.rb
@@ -15,11 +15,15 @@ describe 'Validates HIF return' do
       )
     end
 
-    it 'should return valid if it passes validation' do
+    it 'should return invalid if it fails validation' do
       valid_return = get_use_case(:validate_return).execute(type: 'hif', return_data: project_base_return)
-      expect(valid_return[:valid]).to eq(true)
-      expect(valid_return[:invalid_paths]).to eq([])
-      expect(valid_return[:pretty_invalid_paths]).to eq([])
+      expect(valid_return[:valid]).to eq(false)
+      expect(valid_return[:invalid_paths]).to eq([
+        [:infrastructures, 0, :planning, :outlinePlanning, :planningSubmitted, :percentComplete]
+      ])
+      expect(valid_return[:pretty_invalid_paths]).to eq([
+        ['HIF Project', 'Infrastructures', 'Infrastructure 1', 'Planning', 'Outline Planning', 'Planning Permission Submitted', 'Percent Complete']
+      ])
     end
   end
 end

--- a/spec/acceptance/ui/hif_validate_project_spec.rb
+++ b/spec/acceptance/ui/hif_validate_project_spec.rb
@@ -19,14 +19,18 @@ describe 'Validates HIF Project' do
       INVALID_PATH = [
         [:summary, :sitePlans],
         [:infrastructures, 0, :planningStatus, :planningStatus, :fullPlanningStatus, :granted],
+        [:costs, 0, :infrastructure, :fundedThroughHif, :descriptionOfFundingStack],
         [:costs, 0, :infrastructure, :baselineCashflows],
+        [:recovery, :expectedAmount],
         [:outputs],
         [:rmBaseline]
       ].freeze
       PRETTY_INVALID_PATH = [
         ['HIF Project', 'Project Summary', 'Site Plans'],
         ['HIF Project', 'Infrastructures', 'Infrastructure 1', 'Planning Status', '', 'Full Planning Status', 'Granted?'],
+        ['HIF Project', 'Costs', 'Infrastructure 1', 'Cost','', 'If No: Description of Funding Stack'],
         ['HIF Project', 'Costs', 'Infrastructure 1', 'Cost', 'Baseline Cashflow(s)'],
+        ['HIF Project', 'Recovery', 'Expected Amount'],
         ['HIF Project', 'Outputs'],
         ['HIF Project', 'RM Baseline']
       ].freeze

--- a/spec/acceptance/ui/hif_validate_return_spec.rb
+++ b/spec/acceptance/ui/hif_validate_return_spec.rb
@@ -20,8 +20,14 @@ describe 'Validates HIF return' do
 
       valid_return = get_use_case(:ui_validate_return).execute(type: 'hif', return_data: project_base_return_invalid)
       expect(valid_return[:valid]).to eq(false)
-      expect(valid_return[:invalid_paths]).to eq([%i[s151Confirmation hifFunding cashflowConfirmation]])
-      expect(valid_return[:pretty_invalid_paths]).to eq([['HIF Project', 's151 Confirmation', 'HIF Funding and Profiles', 'Please confirm you are content with the submitted project cashflows']])
+      expect(valid_return[:invalid_paths]).to eq([
+        [:infrastructures, 0, :planning, :outlinePlanning, :planningSubmitted, :percentComplete],
+        %i[s151Confirmation hifFunding cashflowConfirmation]
+      ])
+      expect(valid_return[:pretty_invalid_paths]).to eq([
+        ['HIF Project', 'Infrastructures', 'Infrastructure 1', 'Planning', 'Outline Planning', 'Planning Permission Submitted', 'Percent Complete'],
+        ['HIF Project', 's151 Confirmation', 'HIF Funding and Profiles', 'Please confirm you are content with the submitted project cashflows']
+      ])
     end
   end
 

--- a/spec/unit/homes_england/use_case/validate_project_spec.rb
+++ b/spec/unit/homes_england/use_case/validate_project_spec.rb
@@ -673,6 +673,7 @@ describe HomesEngland::UseCase::ValidateProject do
 
     context 'single dependency' do
       context 'example 1' do
+        it_should_behave_like 'required field validation'
         let(:template) do
           Common::Domain::Template.new.tap do |p|
             p.schema = {
@@ -721,23 +722,10 @@ describe HomesEngland::UseCase::ValidateProject do
             }
           end
         end
-        let(:valid_project_data) { { goodDog: 'Yes', planningSubmitted: {} } }
-        context 'given a valid project' do
-          it 'should return a hash with a valid field as true' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:valid]).to eq(true)
-          end
-
-          it 'should have no paths' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:invalid_paths]).to eq([])
-          end
-
-          it 'should return no pretty paths' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:pretty_invalid_paths]).to eq([])
-          end
-        end
+        let(:valid_project_data) { { goodDog: 'Yes', planningSubmitted: {dogs: 'woof'} } }
+        let(:invalid_project_data) {{ goodDog: 'Yes', planningSubmitted: {}}}
+        let(:invalid_project_data_paths) { [[:planningSubmitted, :dogs]] }
+        let(:invalid_project_data_pretty_paths) { [['Planning Submitted', 'Dogs']] }
       end
     end
   end

--- a/spec/unit/ui/use_case/validate_project_spec.rb
+++ b/spec/unit/ui/use_case/validate_project_spec.rb
@@ -671,8 +671,9 @@ describe UI::UseCase::ValidateProject do
       end
     end
 
-    context 'single dependency' do
+    context 'required field in a dependency' do
       context 'example 1' do
+        it_should_behave_like 'required field validation'
         let(:template) do
           Common::Domain::Template.new.tap do |p|
             p.schema = {
@@ -721,24 +722,401 @@ describe UI::UseCase::ValidateProject do
             }
           end
         end
-        let(:valid_project_data) { { goodDog: 'Yes', planningSubmitted: {} } }
+        let(:valid_project_data) { { goodDog: 'Yes', planningSubmitted: {dogs: 'woof'} } }
+        let(:invalid_project_data) {{ goodDog: 'Yes', planningSubmitted: {}}}
+        let(:invalid_project_data_paths) { [[:planningSubmitted, :dogs]] }
+        let(:invalid_project_data_pretty_paths) { [['Planning Submitted', 'Dogs']] }
+      end
 
-        context 'given a valid project' do
-          it 'should return a hash with a valid field as true' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:valid]).to eq(true)
-          end
-
-          it 'should have no paths' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:invalid_paths]).to eq([])
-          end
-
-          it 'should return no pretty paths' do
-            project_value = use_case.execute(type: project_type, project_data: valid_project_data)
-            expect(project_value[:pretty_invalid_paths]).to eq([])
+      context 'example 2' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              properties: {
+                goodDog: {
+                  type: 'string',
+                  title: 'Is this a good dog?',
+                  enum: %w[Yes No]
+                }
+              },
+              dependencies: {
+                goodDog: {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['No']
+                        }
+                      }
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['Yes']
+                        },
+                        planningSubmitted: {
+                          type: 'string',
+                          title: 'Planning'
+                        },
+                        doggywalked: {
+                          type: 'string',
+                          title: 'Doggy Walks'
+                        }
+                      },
+                      required: ['doggywalked']
+                    }
+                  ]
+                }
+              }
+            }
           end
         end
+        let(:valid_project_data) { { goodDog: 'Yes', doggywalked: 'woof', planningSubmitted: 'Ok' } }
+        let(:invalid_project_data) {{ goodDog: 'Yes', planningSubmitted: 'ok'}}
+        let(:invalid_project_data_paths) { [[:doggywalked]] }
+        let(:invalid_project_data_pretty_paths) { [['Doggy Walks']] }
+      end
+    end
+
+    context 'two required fields in a dependency' do
+      context 'example 1' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              properties: {
+                goodDog: {
+                  type: 'string',
+                  title: 'Is this a good dog?',
+                  enum: %w[Yes No]
+                }
+              },
+              dependencies: {
+                goodDog: {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['No']
+                        }
+                      }
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['Yes']
+                        },
+                        planningSubmitted: {
+                          type: 'object',
+                          title: 'Planning Submitted',
+                          properties: {
+                            dogs: {
+                              title: 'Dogs',
+                              type: 'string'
+                            },
+                            puppies: {
+                              title: 'Puppies',
+                              type: 'string'
+                            }
+                          },
+                          required: ['dogs', 'puppies']
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            }
+          end
+        end
+        let(:valid_project_data) { { goodDog: 'Yes', planningSubmitted: {dogs: 'woof', puppies: 'aawhhooo'} } }
+        let(:invalid_project_data) {{ goodDog: 'Yes', planningSubmitted: {}}}
+        let(:invalid_project_data_paths) { [[:planningSubmitted, :dogs], [:planningSubmitted, :puppies]] }
+        let(:invalid_project_data_pretty_paths) { [['Planning Submitted', 'Dogs'], ['Planning Submitted', 'Puppies']] }
+      end
+
+      context 'example 2' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              properties: {
+                goodDog: {
+                  type: 'string',
+                  title: 'Is this a good dog?',
+                  enum: %w[Yes No]
+                }
+              },
+              dependencies: {
+                goodDog: {
+                  oneOf: [
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['No']
+                        }
+                      }
+                    },
+                    {
+                      type: 'object',
+                      properties: {
+                        goodDog: {
+                          enum: ['Yes']
+                        },
+                        planningSubmitted: {
+                          type: 'string',
+                          title: 'Planning'
+                        },
+                        doggywalked: {
+                          type: 'string',
+                          title: 'Doggy Walks'
+                        },
+                        puppywalked: {
+                          type: 'string',
+                          title: 'Puppy Walks'
+                        }
+                      },
+                      required: ['doggywalked', 'puppywalked']
+                    }
+                  ]
+                }
+              }
+            }
+          end
+        end
+        let(:valid_project_data) { { goodDog: 'Yes', doggywalked: 'woof', puppywalked: 'owwoo', planningSubmitted: 'Ok' } }
+        let(:invalid_project_data) {{ goodDog: 'Yes', planningSubmitted: 'ok'}}
+        let(:invalid_project_data_paths) { [[:doggywalked], [:puppywalked]] }
+        let(:invalid_project_data_pretty_paths) { [['Doggy Walks'], ['Puppy Walks']] }
+      end
+    end
+
+    context 'nested required field in a dependency' do
+      context 'example 1' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              properties: {
+                whatDogs: {
+                  type: 'object',
+                  title: 'What Dogs?',
+                  properties: {
+                    goodDog: {
+                      type: 'string',
+                      title: 'Is this a good dog?',
+                      enum: %w[Yes No]
+                    }
+                  },
+                  dependencies: {
+                    goodDog: {
+                      oneOf: [
+                        {
+                          type: 'object',
+                          properties: {
+                            goodDog: {
+                              enum: ['No']
+                            }
+                          }
+                        },
+                        {
+                          type: 'object',
+                          properties: {
+                            goodDog: {
+                              enum: ['Yes']
+                            },
+                            planningSubmitted: {
+                              type: 'object',
+                              title: 'Planning Submitted',
+                              properties: {
+                                dogs: {
+                                  title: 'Dogs',
+                                  type: 'string'
+                                }
+                              },
+                              required: ['dogs']
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+              }  
+            }
+          end
+        end
+        let(:valid_project_data) { {whatDogs: { goodDog: 'Yes', planningSubmitted: {dogs: 'woof'} }} }
+        let(:invalid_project_data) {{whatDogs: { goodDog: 'Yes', planningSubmitted: {}}}}
+        let(:invalid_project_data_paths) { [[:whatDogs, :planningSubmitted, :dogs]] }
+        let(:invalid_project_data_pretty_paths) { [['What Dogs?', 'Planning Submitted', 'Dogs']] }
+      end
+
+      context 'example 2' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'object',
+              properties: {
+                animalKingdom: {
+                  type: 'object',
+                  title: 'Animal Kingdom',
+                  properties: {
+                    acat: {
+                      type: 'object',
+                      title: 'Cat',
+                      properties: {
+                        needed: {
+                          type: 'string',
+                          title: 'Cat nip'
+                        },
+                        notneeded: {
+                          type: 'string'
+                        }
+                      },
+                      required: ['needed']
+                    },
+                    anotherDog: {
+                      type: 'object',
+                      title: 'Another Dog',
+                      properties: {
+                        goodDog: {
+                          type: 'string',
+                          title: 'Is this a good dog?',
+                          enum: %w[Yes No]
+                        }
+                      },
+                      dependencies: {
+                        goodDog: {
+                          oneOf: [
+                            {
+                              type: 'object',
+                              properties: {
+                                goodDog: {
+                                  enum: ['No']
+                                },
+                                ifApplciable: {
+                                  type: 'string',
+                                  title: 'Not Neccessarily'
+                                }
+                              }
+                            },
+                            {
+                              type: 'object',
+                              properties: {
+                                goodDog: {
+                                  enum: ['Yes']
+                                },
+                                planningSubmitted: {
+                                  type: 'string',
+                                  title: 'Planning'
+                                },
+                                doggywalked: {
+                                  type: 'string',
+                                  title: 'Doggy Walks'
+                                }
+                              },
+                              required: ['doggywalked']
+                            }
+                          ]
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          end
+        end
+        let(:valid_project_data) do 
+          {
+            animalKingdom: {
+              anotherDog: { goodDog: 'No'},
+              acat: { needed: 'Im here' }
+            }
+          }
+        end
+        let(:invalid_project_data) { { animalKingdom: { anotherDog: { goodDog: 'Yes'}, acat: {} }} }
+        let(:invalid_project_data_paths) { [[:animalKingdom, :anotherDog, :doggywalked], [:animalKingdom, :acat, :needed]] }
+        let(:invalid_project_data_pretty_paths) { [['Animal Kingdom', 'Another Dog', 'Doggy Walks'], ['Animal Kingdom', 'Cat', 'Cat nip']] }
+      end
+    end
+
+    context 'required field in a dependency thats in an array' do
+      context 'example 1' do
+        it_should_behave_like 'required field validation'
+        let(:template) do
+          Common::Domain::Template.new.tap do |p|
+            p.schema = {
+              title: 'HIF Project',
+              type: 'array',
+              items: {
+                type: 'object',
+                title: 'Array Item',
+                properties: {
+                  goodDog: {
+                    type: 'string',
+                    title: 'Is this a good dog?',
+                    enum: %w[Yes No]
+                  }
+                },
+                dependencies: {
+                  goodDog: {
+                    oneOf: [
+                      {
+                        type: 'object',
+                        properties: {
+                          goodDog: {
+                            enum: ['No']
+                          }
+                        }
+                      },
+                      {
+                        type: 'object',
+                        properties: {
+                          goodDog: {
+                            enum: ['Yes']
+                          },
+                          planningSubmitted: {
+                            type: 'object',
+                            title: 'Planning Submitted',
+                            properties: {
+                              dogs: {
+                                title: 'Dogs',
+                                type: 'string'
+                              }
+                            },
+                            required: ['dogs']
+                          }
+                        }
+                      }
+                    ]
+                  }
+                }
+              }
+            }
+          end
+        end
+        let(:valid_project_data) { [{ goodDog: 'Yes', planningSubmitted: {dogs: 'woof'} }] }
+        let(:invalid_project_data) {[{ goodDog: 'Yes', planningSubmitted: {}}, { goodDog: 'Yes', planningSubmitted: {dogs: 'woof'}}, { goodDog: 'Yes', planningSubmitted: {}}]}
+        let(:invalid_project_data_paths) { [[0, :planningSubmitted, :dogs], [2, :planningSubmitted, :dogs]] }
+        let(:invalid_project_data_pretty_paths) { [['Array Item 1', 'Planning Submitted', 'Dogs'], ['Array Item 3', 'Planning Submitted', 'Dogs']] }
       end
     end
 

--- a/spec/unit/ui/use_case/validate_return_spec.rb
+++ b/spec/unit/ui/use_case/validate_return_spec.rb
@@ -913,6 +913,8 @@ describe UI::UseCase::ValidateReturn do
 
   context 'single dependency' do
     context 'example 1' do
+      it_should_behave_like 'required field validation'
+
       let(:template) do
         Common::Domain::Template.new.tap do |p|
           p.schema = {
@@ -965,26 +967,14 @@ describe UI::UseCase::ValidateReturn do
       let(:valid_return_data) do
         {
           percentComplete: 'Yes',
-          planningSubmitted: {}
+          planningSubmitted: {dogs: 'hi'}
         }
       end
 
-      context 'given a valid return' do
-        it 'should return a hash with a valid field as true' do
-          return_value = use_case.execute(type: project_type, return_data: valid_return_data)
-          expect(return_value[:valid]).to eq(true)
-        end
+      let(:invalid_return_data) {{ percentComplete: 'Yes', planningSubmitted: {}}}
+      let(:invalid_return_data_paths) { [[:planningSubmitted, :dogs]] }
+      let(:invalid_return_data_pretty_paths) { [['Planning Submitted', 'Dogs']] }
 
-        it 'should have no paths' do
-          return_value = use_case.execute(type: project_type, return_data: valid_return_data)
-          expect(return_value[:invalid_paths]).to eq([])
-        end
-
-        it 'should return no pretty paths' do
-          return_value = use_case.execute(type: project_type, return_data: valid_return_data)
-          expect(return_value[:pretty_invalid_paths]).to eq([])
-        end
-      end
     end
   end
 end


### PR DESCRIPTION
Previously, required fields in dependencies were throwing "one-of" errors. Which were then being filtered out, meaning we couldn't validate them. 