### PR TITLE
Resolve bug with return submission

### DIFF
--- a/lib/common/domain/template.rb
+++ b/lib/common/domain/template.rb
@@ -50,6 +50,7 @@ class Common::Domain::Template
       error.each do |message|
         next if message.to_s.include? "is not a member of"
         next if message.data.nil?
+        next if message.data.is_a? Integer
 
         path =  message.path
         path.shift


### PR DESCRIPTION
Previous changes to error message creation caused issues with array items.
Add edge case where message is an integer (i.e. array level identifier).