### PR TITLE
Add N/A option for jointBidAreas

### DIFF
--- a/lib/ui/gateway/schemas/hif_project.json
+++ b/lib/ui/gateway/schemas/hif_project.json
@@ -392,6 +392,7 @@
           "type": "string",
           "title": "Joint Bid Areas",
           "enum": [
+            "N/A",
             "Adur",
             "Allerdale",
             "Amber Valley",


### PR DESCRIPTION
WHAT:
Adds N/A to the list of options available for jointBidAreas.

WHY:
Was specified that this should be marked as required, but it is a valid case that there may not be a joint bid are.

(Open to comment on whether this should have the required tag removed rather than adding an N/A option)