### PR TITLE
Dont add a user to a project unless it exists

### DIFF
--- a/lib/homes_england/use_case/add_user_to_project.rb
+++ b/lib/homes_england/use_case/add_user_to_project.rb
@@ -1,20 +1,25 @@
 class HomesEngland::UseCase::AddUserToProject
-  def initialize(user_gateway:)
+  def initialize(user_gateway:, project_gateway:)
     @user_gateway = user_gateway
+    @project_gateway = project_gateway
   end
 
   def execute(email:, role: nil, project_id:)
-    user = @user_gateway.find_by(email: email)
-    if user.nil?
-      user = LocalAuthority::Domain::User.new.tap do |u|
-        u.email = email.downcase
-        u.role = role
-        u.projects = [project_id]
+    projects = @project_gateway.all.each do |project|
+      next if project_id != project.id
+
+      user = @user_gateway.find_by(email: email)
+      if user.nil?
+        user = LocalAuthority::Domain::User.new.tap do |u|
+          u.email = email.downcase
+          u.role = role
+          u.projects = [project_id]
+        end
+        @user_gateway.create(user)
+      else
+        user.projects << project_id
+        @user_gateway.update(user)
       end
-      @user_gateway.create(user)
-    else
-      user.projects << project_id
-      @user_gateway.update(user)
     end
   end
 end

--- a/lib/homes_england/use_cases.rb
+++ b/lib/homes_england/use_cases.rb
@@ -66,7 +66,8 @@ class HomesEngland::UseCases
 
     builder.define_use_case :add_user_to_project do
       HomesEngland::UseCase::AddUserToProject.new(
-        user_gateway: builder.get_gateway(:users)
+        user_gateway: builder.get_gateway(:users),
+        project_gateway: builder.get_gateway(:project)
       )
     end
 

--- a/spec/unit/homes_england/use_case/add_user_to_project_spec.rb
+++ b/spec/unit/homes_england/use_case/add_user_to_project_spec.rb
@@ -1,6 +1,22 @@
 describe HomesEngland::UseCase::AddUserToProject do
   let(:user_gateway) { spy(find_by: nil) }
-  let(:use_case) { described_class.new(user_gateway: user_gateway) }
+  let(:project_gateway_spy) do
+    spy(all: [
+      HomesEngland::Domain::Project.new.tap do |p|
+        p.id = 1
+      end,
+      HomesEngland::Domain::Project.new.tap do |p|
+        p.id = 2
+      end,
+      HomesEngland::Domain::Project.new.tap do |p|
+        p.id = 3
+      end,
+      HomesEngland::Domain::Project.new.tap do |p|
+        p.id = 4
+      end
+    ])
+  end
+  let(:use_case) { described_class.new(user_gateway: user_gateway, project_gateway: project_gateway_spy) }
 
   context 'calls the gateway for a user with a lowercase email and a role' do
     it 'example 1' do
@@ -49,6 +65,24 @@ describe HomesEngland::UseCase::AddUserToProject do
         expect(user.email).to eq('cat@cathouse.com')
         expect(user.projects).to eq([8, 3])
       end
+    end
+  end
+
+  context 'the project does not exist' do
+    let(:project_gateway_spy) do
+      spy(
+        all: []
+      )
+    end
+
+    it 'calls the project gateway' do
+      use_case.execute(email: 'email@email', role: 'LA', project_id: 7)
+      expect(project_gateway_spy).to have_received(:all)
+    end
+
+    it 'will not call the user gateway' do
+      expect(user_gateway).not_to have_received(:create)
+      expect(user_gateway).not_to have_received(:update)
     end
   end
 end


### PR DESCRIPTION
When fetching the projects associated to a user it was producing an error when they had a project added to them that didnt exist.
