### PR TITLE
Hide FF infrastructures on main project page

### DIFF
--- a/lib/ui/gateway/schemas/ff_project.json
+++ b/lib/ui/gateway/schemas/ff_project.json
@@ -861,6 +861,7 @@
     },
     "infrastructures": {
       "title": "Infrastructures",
+      "hidden": true,
       "type": "array",
       "items": {
         "title": "Infrastructure",


### PR DESCRIPTION
Part of https://github.com/homes-england/monitor-frontend/pull/291