### PR TITLE
Correct MVF blank baseline

### DIFF
--- a/lib/ui/gateway/blank_projects/mvf.json
+++ b/lib/ui/gateway/blank_projects/mvf.json
@@ -1,7 +1,7 @@
 {
   "summary": {},
   "infrastructures": [{}],
-  "fundingProfiles": {},
+  "fundingProfiles": [{}],
   "costs": [{}],
   "recovery": {},
   "outputs": [{}]

--- a/lib/ui/use_case/convert_ui_hif_project.rb
+++ b/lib/ui/use_case/convert_ui_hif_project.rb
@@ -179,7 +179,7 @@ class UI::UseCase::ConvertUIHIFProject
         instalment3: profile[:instalment3],
         instalment4: profile[:instalment4],
         total: profile[:total]
-    }.compact
+      }.compact
     end
   end
 


### PR DESCRIPTION
Core schema specifies that 'fundingProfiles' is an array, projects created using this blank baseline couldn't be parsed by BI