### PR TITLE
Add template builder for split out schemas

### DIFF
--- a/lib/ui/builder/template.rb
+++ b/lib/ui/builder/template.rb
@@ -11,7 +11,7 @@ class UI::Builder::Template
 
   def add_section(name:, file_name:)
     File.open("#{@path}/#{file_name}") do |f|
-      @schema[:properties][name.to_sym] = JSON.parse(f.read, symbolize_names: true)
+      @schema[:properties][name] = JSON.parse(f.read, symbolize_names: true)
     end
   end
 

--- a/lib/ui/builder/template.rb
+++ b/lib/ui/builder/template.rb
@@ -1,0 +1,23 @@
+class UI::Builder::Template
+  def initialize(path:, title:)
+    @path = path
+    @schema = {
+      '$schema' => 'http://json-schema.org/draft-07/schema',
+      title: title,
+      type: 'object',
+      properties: {}
+    }
+  end
+
+  def add_section(name:, file_name:)
+    File.open("#{@path}/#{file_name}") do |f|
+      @schema[:properties][name.to_sym] = JSON.parse(f.read, symbolize_names: true)
+    end
+  end
+
+  def build
+    Common::Domain::Template.new.tap do |t|
+      t.schema = @schema
+    end
+  end
+end

--- a/lib/ui/builder/template.rb
+++ b/lib/ui/builder/template.rb
@@ -9,9 +9,9 @@ class UI::Builder::Template
     }
   end
 
-  def add_section(name:, file_name:)
+  def add_section(section_name:, file_name:)
     File.open("#{@path}/#{file_name}") do |f|
-      @schema[:properties][name] = JSON.parse(f.read, symbolize_names: true)
+      @schema[:properties][section_name] = JSON.parse(f.read, symbolize_names: true)
     end
   end
 

--- a/lib/ui/gateway/in_memory_project_schema.rb
+++ b/lib/ui/gateway/in_memory_project_schema.rb
@@ -2,28 +2,16 @@
 
 class UI::Gateway::InMemoryProjectSchema
   def find_by(type:)
-    if type == 'hif'
-      schema = 'hif_project.json'
-    elsif type == 'ac'
-      schema = 'ac_project.json'
-    elsif type == 'ff'
-      schema = 'ff_project.json'
-    else
-      return nil
-    end
-    create_template(schema, type)
+    return create_template('hif_project.json') if type == 'hif'
+    return create_template('ac_project.json') if type == 'ac'
+
+    ff_template if type == 'ff'
   end
 
   private
 
-  def create_template(schema, type)
+  def create_template(schema)
     template = Common::Domain::Template.new
-
-    if type == 'ff'
-      template.schema = ff_schema
-
-      return template
-    end
 
     File.open("#{__dir__}/schemas/#{schema}", 'r') do |f|
       template.schema = JSON.parse(
@@ -34,46 +22,15 @@ class UI::Gateway::InMemoryProjectSchema
     template
   end
 
-  def ff_schema
-    path = "#{__dir__}/schemas/ff/project"
+  def ff_template
+    builder = UI::Builder::Template.new(path: "#{__dir__}/schemas/ff/project", title: 'FF Project')
 
-    ff_schema = {
-      '$schema' => 'http://json-schema.org/draft-07/schema',
-      title: 'FF Project',
-      type: 'object',
-      properties: {}
-    }
+    builder.add_section(name: 'summary', file_name: 'summary.json')
+    builder.add_section(name: 'infrastructures', file_name: 'infrastructures.json')
+    builder.add_section(name: 'planning', file_name: 'planning.json')
+    builder.add_section(name: 'landOwnership', file_name: 'land_ownership.json')
+    builder.add_section(name: 'procurement', file_name: 'procurement.json')
 
-    File.open("#{path}/summary.json", 'r') do |file|
-      ff_schema[:properties][:summary] = JSON.parse(
-        file.read, symbolize_names: true
-      )
-    end
-
-    File.open("#{path}/infrastructures.json", 'r') do |file|
-      ff_schema[:properties][:infrastructures] = JSON.parse(
-        file.read, symbolize_names: true
-      )
-    end
-
-    File.open("#{path}/planning.json", 'r') do |file|
-      ff_schema[:properties][:planning] = JSON.parse(
-        file.read, symbolize_names: true
-      )
-    end
-
-    File.open("#{path}/land_ownership.json", 'r') do |file|
-      ff_schema[:properties][:landOwnership] = JSON.parse(
-        file.read, symbolize_names: true
-      )
-    end
-
-    File.open("#{path}/procurement.json", 'r') do |file|
-      ff_schema[:properties][:procurement] = JSON.parse(
-        file.read, symbolize_names: true
-      )
-    end
-
-    ff_schema
+    builder.build
   end
 end

--- a/lib/ui/gateway/in_memory_project_schema.rb
+++ b/lib/ui/gateway/in_memory_project_schema.rb
@@ -25,11 +25,11 @@ class UI::Gateway::InMemoryProjectSchema
   def ff_template
     builder = UI::Builder::Template.new(path: "#{__dir__}/schemas/ff/project", title: 'FF Project')
 
-    builder.add_section(name: :summary, file_name: 'summary.json')
-    builder.add_section(name: :infrastructures, file_name: 'infrastructures.json')
-    builder.add_section(name: :planning, file_name: 'planning.json')
-    builder.add_section(name: :landOwnership, file_name: 'land_ownership.json')
-    builder.add_section(name: :procurement, file_name: 'procurement.json')
+    builder.add_section(section_name: :summary, file_name: 'summary.json')
+    builder.add_section(section_name: :infrastructures, file_name: 'infrastructures.json')
+    builder.add_section(section_name: :planning, file_name: 'planning.json')
+    builder.add_section(section_name: :landOwnership, file_name: 'land_ownership.json')
+    builder.add_section(section_name: :procurement, file_name: 'procurement.json')
 
     builder.build
   end

--- a/lib/ui/gateway/in_memory_project_schema.rb
+++ b/lib/ui/gateway/in_memory_project_schema.rb
@@ -25,11 +25,11 @@ class UI::Gateway::InMemoryProjectSchema
   def ff_template
     builder = UI::Builder::Template.new(path: "#{__dir__}/schemas/ff/project", title: 'FF Project')
 
-    builder.add_section(name: 'summary', file_name: 'summary.json')
-    builder.add_section(name: 'infrastructures', file_name: 'infrastructures.json')
-    builder.add_section(name: 'planning', file_name: 'planning.json')
-    builder.add_section(name: 'landOwnership', file_name: 'land_ownership.json')
-    builder.add_section(name: 'procurement', file_name: 'procurement.json')
+    builder.add_section(name: :summary, file_name: 'summary.json')
+    builder.add_section(name: :infrastructures, file_name: 'infrastructures.json')
+    builder.add_section(name: :planning, file_name: 'planning.json')
+    builder.add_section(name: :landOwnership, file_name: 'land_ownership.json')
+    builder.add_section(name: :procurement, file_name: 'procurement.json')
 
     builder.build
   end

--- a/lib/ui/namespaces.rb
+++ b/lib/ui/namespaces.rb
@@ -1,4 +1,5 @@
 module UI
+  module Builder; end
   module Domain; end
   module Gateway; end
   module UseCase; end

--- a/spec/unit/ui/builder/fixtures/example_one/section_one.json
+++ b/spec/unit/ui/builder/fixtures/example_one/section_one.json
@@ -1,0 +1,4 @@
+{
+  "section": "one",
+  "anotherSection": "two"
+}

--- a/spec/unit/ui/builder/fixtures/example_one/section_two.json
+++ b/spec/unit/ui/builder/fixtures/example_one/section_two.json
@@ -1,0 +1,4 @@
+{
+  "cat": "meow",
+  "dog": "woof"
+}

--- a/spec/unit/ui/builder/fixtures/example_two/cats.json
+++ b/spec/unit/ui/builder/fixtures/example_two/cats.json
@@ -1,0 +1,4 @@
+{
+  "noise": "meow",
+  "softness": "very"
+}

--- a/spec/unit/ui/builder/fixtures/example_two/dogs.json
+++ b/spec/unit/ui/builder/fixtures/example_two/dogs.json
@@ -1,0 +1,4 @@
+{
+  "noise": "woof",
+  "goodBoy": "yes"
+}

--- a/spec/unit/ui/builder/template_spec.rb
+++ b/spec/unit/ui/builder/template_spec.rb
@@ -14,8 +14,8 @@ describe UI::Builder::Template do
     end
 
     it 'Adds the section to the schema properties' do
-      builder.add_section(name: 'sectionOne', file_name: 'section_one.json')
-      builder.add_section(name: 'sectionTwo', file_name: 'section_two.json')
+      builder.add_section(name: :sectionOne, file_name: 'section_one.json')
+      builder.add_section(name: :sectionTwo, file_name: 'section_two.json')
 
       expected_section_one = { section: 'one', anotherSection: 'two' }
       expected_section_two = { cat: 'meow', dog: 'woof' }
@@ -40,8 +40,8 @@ describe UI::Builder::Template do
     end
 
     it 'Adds the section to the schema properties' do
-      builder.add_section(name: 'cats', file_name: 'cats.json')
-      builder.add_section(name: 'dogs', file_name: 'dogs.json')
+      builder.add_section(name: :cats, file_name: 'cats.json')
+      builder.add_section(name: :dogs, file_name: 'dogs.json')
 
       expected_section_one = { noise: 'meow', softness: 'very' }
       expected_section_two = { noise: 'woof', goodBoy: 'yes' }

--- a/spec/unit/ui/builder/template_spec.rb
+++ b/spec/unit/ui/builder/template_spec.rb
@@ -14,8 +14,8 @@ describe UI::Builder::Template do
     end
 
     it 'Adds the section to the schema properties' do
-      builder.add_section(name: :sectionOne, file_name: 'section_one.json')
-      builder.add_section(name: :sectionTwo, file_name: 'section_two.json')
+      builder.add_section(section_name: :sectionOne, file_name: 'section_one.json')
+      builder.add_section(section_name: :sectionTwo, file_name: 'section_two.json')
 
       expected_section_one = { section: 'one', anotherSection: 'two' }
       expected_section_two = { cat: 'meow', dog: 'woof' }
@@ -40,8 +40,8 @@ describe UI::Builder::Template do
     end
 
     it 'Adds the section to the schema properties' do
-      builder.add_section(name: :cats, file_name: 'cats.json')
-      builder.add_section(name: :dogs, file_name: 'dogs.json')
+      builder.add_section(section_name: :cats, file_name: 'cats.json')
+      builder.add_section(section_name: :dogs, file_name: 'dogs.json')
 
       expected_section_one = { noise: 'meow', softness: 'very' }
       expected_section_two = { noise: 'woof', goodBoy: 'yes' }

--- a/spec/unit/ui/builder/template_spec.rb
+++ b/spec/unit/ui/builder/template_spec.rb
@@ -1,0 +1,53 @@
+describe UI::Builder::Template do
+  describe 'Example one' do
+    let(:builder) do
+      described_class.new(
+        title: 'Example one',
+        path: "#{__dir__}/fixtures/example_one"
+      )
+    end
+
+    let(:template) { builder.build }
+
+    it 'Has the title in the schema' do
+      expect(template.schema[:title]).to eq('Example one')
+    end
+
+    it 'Adds the section to the schema properties' do
+      builder.add_section(name: 'sectionOne', file_name: 'section_one.json')
+      builder.add_section(name: 'sectionTwo', file_name: 'section_two.json')
+
+      expected_section_one = { section: 'one', anotherSection: 'two' }
+      expected_section_two = { cat: 'meow', dog: 'woof' }
+
+      expect(template.schema[:properties][:sectionOne]).to eq(expected_section_one)
+      expect(template.schema[:properties][:sectionTwo]).to eq(expected_section_two)
+    end
+  end
+
+  describe 'Example two' do
+    let(:builder) do
+      described_class.new(
+        title: 'Example two',
+        path: "#{__dir__}/fixtures/example_two"
+      )
+    end
+
+    let(:template) { builder.build }
+
+    it 'Has the title in the schema' do
+      expect(template.schema[:title]).to eq('Example two')
+    end
+
+    it 'Adds the section to the schema properties' do
+      builder.add_section(name: 'cats', file_name: 'cats.json')
+      builder.add_section(name: 'dogs', file_name: 'dogs.json')
+
+      expected_section_one = { noise: 'meow', softness: 'very' }
+      expected_section_two = { noise: 'woof', goodBoy: 'yes' }
+
+      expect(template.schema[:properties][:cats]).to eq(expected_section_one)
+      expect(template.schema[:properties][:dogs]).to eq(expected_section_two)
+    end
+  end
+end


### PR DESCRIPTION
What:
- Adds a template builder to allow for building up sections of a larger more complex schema

Currently only supports adding sections in the properties -will need to be extended as we go to split up the current schemas to add additional top level items