### PR TITLE
Authorise users against projects stored in the database

### DIFF
--- a/lib/local_authority/use_case/check_api_key.rb
+++ b/lib/local_authority/use_case/check_api_key.rb
@@ -4,7 +4,6 @@ class LocalAuthority::UseCase::CheckApiKey
   end
 
   def execute(api_key:, project_id:)
-
     project_id = project_id.to_i unless project_id.nil?
 
     begin
@@ -15,7 +14,7 @@ class LocalAuthority::UseCase::CheckApiKey
 
       if project_id.nil?
         { valid: true, email: api_key_email, role: api_key_role }
-      elsif user_projects.any? { |p| p[:id] == project_id }
+      elsif has_permission_for_project?(project_id, user_projects)
         { valid: true, email: api_key_email, role: api_key_role }
       else
         { valid: false }
@@ -34,5 +33,9 @@ class LocalAuthority::UseCase::CheckApiKey
       true,
       algorithm: 'HS512'
     )[0]
+  end
+
+  def has_permission_for_project?(project_id, user_projects)
+    user_projects.any? { |p| p[:id] == project_id }
   end
 end

--- a/lib/local_authority/use_case/check_api_key.rb
+++ b/lib/local_authority/use_case/check_api_key.rb
@@ -1,17 +1,21 @@
 class LocalAuthority::UseCase::CheckApiKey
+  def initialize(get_user_projects:)
+    @get_user_projects = get_user_projects
+  end
+
   def execute(api_key:, project_id:)
 
     project_id = project_id.to_i unless project_id.nil?
 
     begin
       payload = get_payload(api_key)
-      api_key_projects = payload['projects']
       api_key_email = payload['email']
       api_key_role = payload['role']
+      user_projects = @get_user_projects.execute(email: api_key_email)[:project_list]
 
       if project_id.nil?
         { valid: true, email: api_key_email, role: api_key_role }
-      elsif api_key_projects.include?(project_id)
+      elsif user_projects.any? { |p| p[:id] == project_id }
         { valid: true, email: api_key_email, role: api_key_role }
       else
         { valid: false }

--- a/lib/local_authority/use_cases.rb
+++ b/lib/local_authority/use_cases.rb
@@ -117,7 +117,9 @@ class LocalAuthority::UseCases
     end
 
     builder.define_use_case :check_api_key do
-      LocalAuthority::UseCase::CheckApiKey.new
+      LocalAuthority::UseCase::CheckApiKey.new(
+        get_user_projects: builder.get_use_case(:get_user_projects)
+      )
     end
 
     builder.define_use_case :validate_return do

--- a/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
+++ b/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
@@ -3,7 +3,7 @@
 require 'rspec'
 require_relative '../shared_context/dependency_factory'
 
-fdescribe 'Authorises the user' do
+describe 'Authorises the user' do
   let(:project_id) do
     get_use_case(:ui_create_project).execute(
       type: 'hif',

--- a/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
+++ b/spec/acceptance/local_authority/authorise_user_with_project_spec.rb
@@ -3,7 +3,15 @@
 require 'rspec'
 require_relative '../shared_context/dependency_factory'
 
-describe 'Authorises the user' do
+fdescribe 'Authorises the user' do
+  let(:project_id) do
+    get_use_case(:ui_create_project).execute(
+      type: 'hif',
+      name: 'cat sanctuary',
+      baseline: nil,
+      bid_id: '12345'
+    )[:id]
+  end
   include_context 'dependency factory'
 
   before do
@@ -11,7 +19,7 @@ describe 'Authorises the user' do
     ENV['HMAC_SECRET'] = 'Meow'
 
     get_use_case(:add_user).execute(email: 'cat@cathouse.com', role: 'HomesEngland')
-    get_use_case(:add_user_to_project).execute(project_id: 1, email: 'cat@cathouse.com')
+    get_use_case(:add_user_to_project).execute(project_id: project_id, email: 'cat@cathouse.com')
   end
 
   after { get_gateway(:access_token).clear }
@@ -26,14 +34,23 @@ describe 'Authorises the user' do
     end
 
     it 'should create a valid api key for project 1' do
-      api_key = get_use_case(:create_api_key).execute(projects: [1], email: 'cat@cathouse.com', role: 'HomesEngland')[:api_key]
-      expect(get_use_case(:check_api_key).execute(api_key: api_key, project_id: 1)).to eq(valid: true, email: 'cat@cathouse.com', role: 'HomesEngland')
+      access_token = get_use_case(:create_access_token).execute(email: 'cat@cathouse.com')[:access_token]
+      api_key = get_use_case(:expend_access_token).execute(access_token: access_token)[:api_key]
+
+      expect(get_use_case(:check_api_key).execute(api_key: api_key, project_id: project_id)).to(
+        eq(
+          valid: true,
+          email: 'cat@cathouse.com',
+          role: 'HomesEngland'
+        )
+      )
     end
   end
 
   context 'Incorrect project' do
     it 'Should have an incorrect apikey for the project' do
-      api_key = get_use_case(:create_api_key).execute(projects: [1], email: 'cat@cathouse.com', role: 'HomesEngland')[:api_key]
+      access_token = get_use_case(:create_access_token).execute(email: 'cat@cathouse.com')[:access_token]
+      api_key = get_use_case(:expend_access_token).execute(access_token: access_token)[:api_key]
       expect(get_use_case(:check_api_key).execute(api_key: api_key, project_id: 2)).to eq(valid: false)
     end
   end

--- a/spec/unit/local_authority/use_case/check_api_key_spec.rb
+++ b/spec/unit/local_authority/use_case/check_api_key_spec.rb
@@ -1,4 +1,4 @@
-fdescribe LocalAuthority::UseCase::CheckApiKey do
+describe LocalAuthority::UseCase::CheckApiKey do
   let(:user_projects) { { project_list: [] } }
   let(:get_user_projects_stub) { double(execute: user_projects) }
   let(:use_case) do

--- a/spec/unit/local_authority/use_case/check_api_key_spec.rb
+++ b/spec/unit/local_authority/use_case/check_api_key_spec.rb
@@ -1,13 +1,17 @@
-describe LocalAuthority::UseCase::CheckApiKey do
-  let(:use_case) { described_class.new }
+fdescribe LocalAuthority::UseCase::CheckApiKey do
+  let(:user_projects) { { project_list: [] } }
+  let(:get_user_projects_stub) { double(execute: user_projects) }
+  let(:use_case) do
+    described_class.new(get_user_projects: get_user_projects_stub)
+  end
 
   def one_hour_in_seconds
     3600
   end
 
-  def api_key_for_project(projects, email, role, api_key=ENV['HMAC_SECRET'])
+  def api_key_for_user(email, role, api_key = ENV['HMAC_SECRET'])
     one_hour_from_now = (Time.now.to_i + one_hour_in_seconds)
-    JWT.encode({projects: projects, email: email, exp: one_hour_from_now, role: role}, api_key, 'HS512')
+    JWT.encode({ email: email, exp: one_hour_from_now, role: role }, api_key, 'HS512')
   end
 
   context 'Example one' do
@@ -33,21 +37,21 @@ describe LocalAuthority::UseCase::CheckApiKey do
 
       context 'That is signed by a different key' do
         it 'returns invalid' do
-          api_key = api_key_for_project(1, 'dog@doghause.com', 'HomesEngland', 'dogs')
+          api_key = api_key_for_user('dog@doghause.com', 'HomesEngland', 'dogs')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:valid]).to eq(false)
         end
 
         it 'does not return an email' do
-          api_key = api_key_for_project(1, 'dog@doghause.com', 'HomesEngland', 'dogs')
+          api_key = api_key_for_user('dog@doghause.com', 'HomesEngland', 'dogs')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:email]).to eq(nil)
         end
 
         it 'does not return a role' do
-          api_key = api_key_for_project(1, 'dog@doghause.com', 'HomesEngland', 'dogs')
+          api_key = api_key_for_user('dog@doghause.com', 'HomesEngland', 'dogs')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:email]).to eq(nil)
@@ -58,7 +62,7 @@ describe LocalAuthority::UseCase::CheckApiKey do
         it 'returns invalid' do
           api_key = JWT.encode(
             {
-              project_id: 1, exp: Time.new(2010, 01, 01).to_i
+              exp: Time.new(2010, 1, 1).to_i
             },
             ENV['HMAC_SECRET'],
             'HS512'
@@ -71,7 +75,7 @@ describe LocalAuthority::UseCase::CheckApiKey do
         it 'does not return an email' do
           api_key = JWT.encode(
             {
-              project_id: 1, exp: Time.new(2010, 01, 01).to_i
+              exp: Time.new(2010, 01, 01).to_i
             },
             ENV['HMAC_SECRET'],
             'HS512'
@@ -84,16 +88,18 @@ describe LocalAuthority::UseCase::CheckApiKey do
     end
 
     context 'given a valid api key' do
-      context 'For a different project' do
+      context 'And the user is not on the project' do
+        let(:user_projects) { { project_list: [{ id: 1 }] } }
+
         it 'Returns invalid' do
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
 
           response = use_case.execute(api_key: api_key, project_id: '5')
           expect(response[:valid]).to eq(false)
         end
 
         it 'does not return an email' do
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
 
           response = use_case.execute(api_key: api_key, project_id: '5')
           expect(response[:email]).to eq(nil)
@@ -101,46 +107,48 @@ describe LocalAuthority::UseCase::CheckApiKey do
       end
 
       context 'For the correct project' do
+        let(:user_projects) { { project_list: [{ id: 1 }] } }
+
         it 'Returns valid' do
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:valid]).to eq(true)
         end
 
         it 'returns an email' do
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:email]).to eq('cat@cathouse.com')
         end
 
         it 'returns a role' do
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:role]).to eq('LocalAuthority')
         end
       end
 
-      context 'for no project' do 
-        it 'returns valid' do 
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
-        
+      context 'for no project' do
+        it 'returns valid' do
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
+
           response = use_case.execute(api_key: api_key, project_id: nil)
           expect(response[:valid]).to eq(true)
         end
 
-        it 'returns an email' do 
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
-        
+        it 'returns an email' do
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
+
           response = use_case.execute(api_key: api_key, project_id: nil)
           expect(response[:email]).to eq('cat@cathouse.com')
         end
 
-        it 'returns a role' do 
-          api_key = api_key_for_project([1], 'cat@cathouse.com', 'LocalAuthority')
-        
+        it 'returns a role' do
+          api_key = api_key_for_user('cat@cathouse.com', 'LocalAuthority')
+
           response = use_case.execute(api_key: api_key, project_id: nil)
           expect(response[:role]).to eq('LocalAuthority')
         end
@@ -166,14 +174,14 @@ describe LocalAuthority::UseCase::CheckApiKey do
 
       context 'That is signed by a different key' do
         it 'returns invalid' do
-          api_key = api_key_for_project([5], 'cats@meow.com', 's151', 'meow')
+          api_key = api_key_for_user('cats@meow.com', 's151', 'meow')
 
           response = use_case.execute(api_key: api_key, project_id: '5')
           expect(response[:valid]).to eq(false)
         end
 
         it 'does not return an email' do
-          api_key = api_key_for_project([6], 'cats@meow.com', 's151', 'meow')
+          api_key = api_key_for_user('cats@meow.com', 's151', 'meow')
 
           response = use_case.execute(api_key: 'dogs', project_id: '1')
           expect(response[:email]).to eq(nil)
@@ -183,63 +191,68 @@ describe LocalAuthority::UseCase::CheckApiKey do
 
     context 'given a valid api key' do
       context 'For a different project' do
+        let(:user_projects) { { project_list: [{ id: 3 }, { id: 4 }, { id: 5 }] } }
+
         it 'Returns invalid' do
-          api_key = api_key_for_project([5], 'cats@ny.an', 's151')
+          api_key = api_key_for_user('cats@ny.an', 's151')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:valid]).to eq(false)
         end
 
         it 'does not return an email' do
-          api_key = api_key_for_project([6], 'cats@meow.com', 's151', 'meow')
+          api_key = api_key_for_user('cats@meow.com', 's151', 'meow')
 
           response = use_case.execute(api_key: api_key, project_id: '1')
           expect(response[:email]).to eq(nil)
         end
 
-        it 'returns a role' do
-          api_key = api_key_for_project([6], 'cats@meow.com', 's151')
-
-          response = use_case.execute(api_key: api_key, project_id: '6')
-          expect(response[:role]).to eq('s151')
-        end
       end
 
       context 'For the correct project' do
+        let(:user_projects) { { project_list: [{ id: 3 }, { id: 4 }, { id: 5 }] } }
+
         it 'Returns valid' do
-          api_key = api_key_for_project([5], 'cats@ny.an', 's151')
+          api_key = api_key_for_user('cats@ny.an', 's151')
 
           response = use_case.execute(api_key: api_key, project_id: '5')
           expect(response[:valid]).to eq(true)
         end
 
         it 'returns an email' do
-          api_key = api_key_for_project([5], 'cats@meow.com', 's151')
+          api_key = api_key_for_user('cats@meow.com', 's151')
 
           response = use_case.execute(api_key: api_key, project_id: '5')
           expect(response[:email]).to eq('cats@meow.com')
         end
+
+        it 'returns a role' do
+          api_key = api_key_for_user('cats@meow.com', 's151')
+
+          response = use_case.execute(api_key: api_key, project_id: '5')
+          expect(response[:role]).to eq('s151')
+        end
       end
     end
 
-    context 'for no project' do 
-      it 'returns valid' do 
-          api_key = api_key_for_project([5], 'cats@ny.an', 's151')
-      
+    context 'for no project' do
+      it 'returns valid' do
+        api_key = api_key_for_user('cats@ny.an', 's151')
+
         response = use_case.execute(api_key: api_key, project_id: nil)
         expect(response[:valid]).to eq(true)
       end
 
-      it 'returns an email' do 
-          api_key = api_key_for_project([5], 'cats@ny.an', 's151')
-      
+      it 'returns an email' do
+        api_key = api_key_for_user('cats@ny.an', 's151')
+
         response = use_case.execute(api_key: api_key, project_id: nil)
         expect(response[:email]).to eq('cats@ny.an')
       end
 
-      it 'returns a role' do 
-          api_key = api_key_for_project([5], 'cats@ny.an', 's151')
-      
+      it 'returns a role' do
+        api_key = api_key_for_user('cats@ny.an', 's151')
+
         response = use_case.execute(api_key: api_key, project_id: nil)
         expect(response[:role]).to eq('s151')
       end

--- a/spec/unit/local_authority/use_case/check_api_key_spec.rb
+++ b/spec/unit/local_authority/use_case/check_api_key_spec.rb
@@ -181,7 +181,7 @@ fdescribe LocalAuthority::UseCase::CheckApiKey do
         end
 
         it 'does not return an email' do
-          api_key = api_key_for_user('cats@meow.com', 's151', 'meow')
+          api_key_for_user('cats@meow.com', 's151', 'meow')
 
           response = use_case.execute(api_key: 'dogs', project_id: '1')
           expect(response[:email]).to eq(nil)


### PR DESCRIPTION
This removes the need to login every time you get added to a project, and will allow us to remove people from projects which will revoke their API key

The frontend will need to be updated to no longer delete cookies on project creation in order to take advantage of this