### PR TITLE
Remove minitems from AC Financials

### DIFF
--- a/lib/ui/gateway/schemas/ac_project.json
+++ b/lib/ui/gateway/schemas/ac_project.json
@@ -660,7 +660,6 @@ set(formData, 'numberOfUnitsTotal', get(formData, 'numberOfUnits') ?
           "quarterly": true,
           "addable": true,
           "title": "Funding Drawdown",
-          "minItems": 3,
           "items": {
             "type": "object",
             "required": [


### PR DESCRIPTION
Currently RJSF has an issue where using minitems in our quarterly component will cause the initial items to all replicate each other when changing them

Until this is resolved it is easier to remove the minitems here as a workaround