### PR TITLE
Unlink outputs from infrastructures array

### DIFF
--- a/lib/ui/gateway/schemas/hif_project.json
+++ b/lib/ui/gateway/schemas/hif_project.json
@@ -871,7 +871,7 @@
     "infrastructures": {
       "type": "array",
       "addable": true,
-      "linkedArray": ["costs", "outputs"],
+      "linkedArray": ["costs"],
       "title": "Infrastructures",
       "items": {
         "title": "Infrastructure",


### PR DESCRIPTION
the changing of outputs to an array was done to aid the BI work and doesnt actually reflect what happens in the internal data

to prevent us creating data that wont be saved we have unlinked these arrays